### PR TITLE
Fixed cyclical instructions for installation via PowerShell

### DIFF
--- a/WSL/install-manual.md
+++ b/WSL/install-manual.md
@@ -29,7 +29,7 @@ If the Microsoft Store app is not available, you can download and manually insta
 * [OpenSUSE](https://aka.ms/wsl-opensuse-42)
 * [SLES](https://aka.ms/wsl-sles-12)
 
-This will cause the `<distro>.appx` packages to download to a folder of your choosing. Follow the [installation instructions](#installing_your_distro) to install your downloaded distro(s).
+This will cause the `<distro>.appx` packages to download to a folder of your choosing. Follow the [installation instructions](#Installing-your-distro) to install your downloaded distro(s).
 
 ## Downloading distros via the command line
 If you prefer, you can also download your preferred distro(s) via the command line:
@@ -56,4 +56,9 @@ In the above example, `curl.exe` is executed (not just `curl`) to ensure that, i
 > Note: Using `curl` might be preferable if you have to invoke/script download steps using Cmd shell and/or `.bat` / `.cmd` scripts.
 
 # Installing your distro
-For instructions on how to install your downloaded distro(s), please refer to the [Windows Desktop](install-win10.md) or [Windows Server](install-on-server.md) installation instructions.
+Using PowerShell, navigate to folder containing the distro downloaded from above. In that directory run the following cmd where `app_name` is the name of your distro .appx file.  
+```
+Add-AppxPackage .\app_name.appx
+```
+
+Now that it is installed you'll need to refer to the [Intilization Steps](initialize-distro.md) to complete initilization of new distro.


### PR DESCRIPTION
The instructions now fully explain how to install via PowerShell and then links user to initializing step.
See issue #265 