### PR TITLE
Updated commands for Ubuntu 18.04

### DIFF
--- a/WSL/user-support.md
+++ b/WSL/user-support.md
@@ -95,6 +95,8 @@ Step by step instructions using Ubuntu:
 
     ```console
     C:\> ubuntu config --default-user root
+    # If you are using Ubuntu 18.04 in WSL, change the command to ubuntu1804
+    # ubuntu1804 config --default-user root
     ```    
 
 1. Launch your Linux distribution (`ubuntu`).  You will automatically login as `root`:
@@ -109,6 +111,8 @@ Step by step instructions using Ubuntu:
 
     ```console
     C:\> ubuntu config --default-user username
+    # If you are using Ubuntu 18.04 in WSL, change the command to ubuntu1804
+    ubuntu config --default-user username
     ```
 
 ## Permissions


### PR DESCRIPTION
Instructions to reset password for Ubuntu is outdated, it does not work for latest Ubuntu 18.04. I Updated documentation to reflect this change.