### PR TITLE
Renames title and recommends wsl.exe

### DIFF
--- a/WSL/reference.md
+++ b/WSL/reference.md
@@ -1,5 +1,5 @@
 ---
-title: Windows Subsystem for Linux Command Reference
+title: Windows Subsystem for Linux Command Reference (for Windows 10 1709 and under)
 description: List of commands that manage the Windows Subsystem for Linux
 keywords: BashOnWindows, bash, wsl, windows, windows subsystem for linux, windowssubsystem, ubuntu
 author: scooley
@@ -12,7 +12,7 @@ ms.custom: seodec18
 
 # Command Reference for Windows Subsystem for Linux
 
-> `lxrun.exe` is deprecated as of Windows 10 1803 and later.
+> `lxrun.exe` is deprecated as of Windows 10 1803 and later. Please use `wsl.exe`. This will be further documented in Windows Subsystem for Linux Command Reference (for Windows 10 1803 and up) when it becomes available. 
 
 The command `lxrun.exe` can be used to interact with the [Windows Subsystem for Linux (WSL)](https://msdn.microsoft.com/en-us/commandline/wsl/faq#what-windows-subsystem-for-linux-wsl-) directly.  These commands are installed into the `\Windows\System32` directory and may be run within a Windows command prompt or in PowerShell.
 


### PR DESCRIPTION
This doc is still needed as is for developers running versions of Windows 10 under 1803. This simply makes that more clearly known so developers who are on newer versions know to ignore this doc and use the recommended method. Since this doc needs to be maintained, renaming it will be helpful so that a new page can be created that shows the supported procedure.