### PR TITLE
update broken link to instructions for forcing diagnostic crash dumps on hangs

### DIFF
--- a/WSL/troubleshooting.md
+++ b/WSL/troubleshooting.md
@@ -121,7 +121,7 @@ Administrator privileges in Windows are required to run ping in WSL.  To run pin
 If while working with bash, you find that bash is hung (or deadlocked) and not responding to inputs, help us diagnose the issue by collecting and reporting a memory dump. Note that these steps will crash your system. Do not do this if you are not comfortable with that or save your work prior to doing this.  <br/>
 To collect a memory dump:
 1. Change the memory dump type to "complete memory dump". While changing the dump type, take a note of your current type.
-2. Use the [steps](https://blogs.technet.microsoft.com/askpfeplat/2015/04/05/how-to-force-a-diagnostic-memory-dump-when-a-computer-hangs/) to configure crash using keyboard control.
+2. Use the [steps](https://techcommunity.microsoft.com/t5/Core-Infrastructure-and-Security/How-to-Force-a-Diagnostic-Memory-Dump-When-a-Computer-Hangs/ba-p/257809) to configure crash using keyboard control.
 3. Repro the hang or deadlock.
 4. Crash the system using the key sequence from (2).
 5. The system will crash and collect the memory dump.


### PR DESCRIPTION

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>