### PR TITLE
Remove extra backtick from previous commit

### DIFF
--- a/WSL/wsl2-install.md
+++ b/WSL/wsl2-install.md
@@ -48,7 +48,7 @@ and make sure to replace `<Distro>` with the actual name of your distro. (You ca
 Additionally, if you want to make WSL 2 your default architecture you can do so with this command:
 
 ```
-wsl --set-default-version 2`
+wsl --set-default-version 2
 ```
 
 This will make any new distro that you install be initialized as a WSL 2 distro.


### PR DESCRIPTION
The previous commit changed several inline code markup into code blocks, and accidently left behind a backtick.