### PR TITLE
update instructions to include slow ring

### DIFF
--- a/WSL/wsl2-install.md
+++ b/WSL/wsl2-install.md
@@ -15,7 +15,7 @@ To install and start using WSL 2 complete the following steps:
 > WSL 2 is only available in Windows 10 builds 18917 or higher
 
 - Ensure that you have WSL installed (you can find instructions to do so [here](./install-win10.md)) and that you are running Windows 10 **build 18917** or higher
-   - To make sure you are using build 18917 or higher please join [the Windows Insider Program](https://insider.windows.com/en-us/) and select the 'Fast' ring. 
+   - To make sure you are using build 18917 or higher please join [the Windows Insider Program](https://insider.windows.com/en-us/) and select the 'Fast' ring or the 'Slow' ring. 
    - You can check your Windows version by opening Command Prompt and running the `ver` command.
 - Enable the 'Virtual Machine Platform' optional component
 - Set a distro to be backed by WSL 2 using the command line


### PR DESCRIPTION
WSL2 is now available for the 'Slow' ring as well but the documentation says you need to use the fast ring.