### PR TITLE
Activate links to Ubuntu 18.04

### DIFF
--- a/WSL/install-manual.md
+++ b/WSL/install-manual.md
@@ -19,10 +19,8 @@ In these cases, while WSL itself is available, how do you download and install L
 ## Downloading distros
 
 If the Microsoft Store app is not available, you can download and manually install Linux distros by clicking these links:
-<!-- * [Ubuntu 18.04](https://aka.ms/wsl-ubuntu-1804)
-* [Ubuntu 18.04 ARM](https://aka.ms/wsl-ubuntu-1804-arm) -->
-* Ubuntu 18.04
-* Ubuntu 18.04 ARM
+* [Ubuntu 18.04](https://aka.ms/wsl-ubuntu-1804)
+* [Ubuntu 18.04 ARM](https://aka.ms/wsl-ubuntu-1804-arm)
 * [Ubuntu 16.04](https://aka.ms/wsl-ubuntu-1604)
 * [Debian GNU/Linux](https://aka.ms/wsl-debian-gnulinux)
 * [Kali Linux](https://aka.ms/wsl-kali-linux-new)


### PR DESCRIPTION
Links were already added correctly but behind a comment without direct reasoning. I checked both and they work, so I assume we can activate them again, for easing the use for the end-user.