### PR TITLE
Issue #594: Incorrect Platform AMD64 instead of x64

### DIFF
--- a/WSL/wsl2-kernel.md
+++ b/WSL/wsl2-kernel.md
@@ -15,7 +15,7 @@ To manually update the Linux kernel inside of WSL 2 please follow these steps.
 
 ## Download the Linux kernel update package
 
-Please click on [this link](https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi) to download the latest WSL2 Linux kernel update package for AMD64 machines.
+Please click on [this link](https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi) to download the latest WSL2 Linux kernel update package for x64 machines.
 
 > [!NOTE] 
 > If you're using an ARM64 machine, please download [this package](https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_arm64.msi) instead.


### PR DESCRIPTION
The download link points to x64 but the text mentions it as AMD64. There is a separate note section below for AMD64