### PR TITLE
Fix redirect URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you find doc issues / errors or have an improvement you'd like to suggest, pl
 > **Note:** This repo's issue tracker is only for reporting issues with the WSL docs.
 > Other related issue repo's:
 > * WSL: https://github.com/Microsoft/WSL/
-> * Windows Console: https://github.com/Microsoft/Console/
+> * Windows Console: https://github.com/Microsoft/Terminal/
 
 ## External Links
 


### PR DESCRIPTION
Changes the redirect url of `Microsoft/Console` to `Microsoft/Terminal`