### PR TITLE
Add redirect for initialize > install page

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -3,7 +3,7 @@
     {
       "source_path": "wsl/install_guide.md",
       "redirect_url": "/windows/wsl/install-win10",
-      "redirect_document_id": true
+      "redirect_document_id": false
     },
     {
       "source_path": "wsl/user_support.md",
@@ -19,6 +19,11 @@
       "source_path": "WSL/index.md",
       "redirect_url": "about",
       "redirect_document_id": false
+    },
+    {
+      "source_path": "wsl/initialize-distro.md",
+      "redirect_url": "wsl/install-win10",
+      "redirect_document_id": true
     }
   ]
 }


### PR DESCRIPTION
Here's what you need to know:
{
    "redirections": [
        {
            "source_path": "wsl/subfolder/deprecated_file_name.md",
            "redirect_url": "wsl/destination_file_name",
            "redirect_document_id": true
        },

1. source_path is the location of the file that we are getting rid of with a .md.
2. redirect_url is the location that you want that URL to redirect to... no .md. You can also use an entire URL (rather than a relative link) here if you prefer. For example: https://docs.microsoft.com/windows/wsl (be sure not to include the en-us language-location part of the url). 
3. redirect_document_id is true or false and determines whether the traffic data from the old page should be pulled to the new redirect page. For most new redirects this should be true... BUT you can only set this to true for a destination page once. You'll see that I changed an old redirect to the install page to false because it likely doesn't get traffic any more since it's old... but I do want the install page to get the data from the initialize page that we are depricating... so I set that to true. 
4. Be aware of commas since this is a JSON file... there needs to be a comma between statements / brackets, but no comma for the very last statement. {statement}, {statement}
5. We can add as many of these as we would like... let's make sure that we capture ALL urls that may be changing and test them to be sure that they work once we publish.