### PR TITLE
Removing references to upcoming Windows v2004 release

### DIFF
--- a/WSL/compare-versions.md
+++ b/WSL/compare-versions.md
@@ -28,7 +28,7 @@ Feature | WSL 1 | WSL 2
 
 Already using WSL 1 and want to upgrade to WSL 2? Follow the instructions to [update to WSL 2](./install-win10.md#update-to-wsl-2)!
 
-WSL 2 is only available in Windows 10, Version 2004, Build 19041 or higher. You will need to [update your Windows version](ms-settings:windowsupdate) and [join the Windows Insider program](https://insider.windows.com/insidersigninboth/) on the "Release Preview" ring until the public release in late May.
+WSL 2 is only available in Windows 10, Version 2004, Build 19041 or higher.
 
 ## Use the Linux file system for faster performance
 

--- a/WSL/install-on-server.md
+++ b/WSL/install-on-server.md
@@ -24,7 +24,7 @@ Open PowerShell as Administrator and run:
 
 **If you're looking for 100% system call compatibility and faster IO performance, read below to install WSL 2!**
 
-WSL 2 is only available in Windows 10, Version 2004, Build 19041 or higher. You will need to [update your Windows version](ms-settings:windowsupdate) and [join the Windows Insider program](https://insider.windows.com/insidersigninboth/) on the "Release Preview" ring until the public release in late May.
+WSL 2 is only available in Windows 10, Version 2004, Build 19041 or higher. 
 
 **If continuing with WSL 1, restart your machine when prompted and continue with installation [here](./install-on-server.md#download-a-linux-distribution)**
 

--- a/WSL/install-win10.md
+++ b/WSL/install-win10.md
@@ -27,9 +27,6 @@ To update to WSL 2, you must meet the follow criteria:
 
 - Running Windows 10, [updated to version 2004](ms-settings:windowsupdate), **Build 19041** or higher.
 
-> [!IMPORTANT]
-> Currently to update to Windows 10, version 2004 (Build 19041), you will need to [join the Windows Insider program](https://insider.windows.com/insidersigninboth/) and select the "Release Preview" ring. The public release should arrive by late May.
-
 - Check your Windows version by selecting the **Windows logo key + R**, type **winver**, select **OK**. (Or enter the `ver` command in Windows Command Prompt). Please [update to the latest Windows version](ms-settings:windowsupdate) if your build is lower than 19041. [Get Windows Update Assistant](https://www.microsoft.com/software-download/windows10).
 
 ### Enable the 'Virtual Machine Platform' optional component

--- a/WSL/wsl2-index.md
+++ b/WSL/wsl2-index.md
@@ -11,7 +11,7 @@ ms.localizationpriority: high
 
 WSL 2 is a new version of the architecture in WSL that changes how Linux distributions interact with Windows. WSL 2 has the primary goals of increasing file system performance and adding full system call compatibility. Each Linux distribution can run as WSL 1 or a WSL 2 and can be switched between at any time. WSL 2 is a major overhaul of the underlying architecture and uses virtualization technology and a Linux kernel to enable its new features.
 
-WSL 2 is only available in Windows 10, Version 2004, Build 19041 or higher. You will need to [update your Windows version](ms-settings:windowsupdate) and [join the Windows Insider program](https://insider.windows.com/insidersigninboth/) on the "Release Preview" ring until the public release in late May.
+WSL 2 is only available in Windows 10, Version 2004, Build 19041 or higher.
 
 [Update from WSL 1 to WSL 2](./install-win10.md#update-to-wsl-2)
 


### PR DESCRIPTION
This PR is to remove all out of date references to the _upcoming_ release of version 2004.

Example:

Before:
![image](https://user-images.githubusercontent.com/215187/82852955-254a8300-9eb9-11ea-920c-5ff8e9a78cb4.png)


After:
![image](https://user-images.githubusercontent.com/215187/82852967-2f6c8180-9eb9-11ea-8a4d-32d6fdffdb7e.png)


