### PR TITLE
Fix bullet point formatting on About page

### DIFF
--- a/WSL/about.md
+++ b/WSL/about.md
@@ -18,8 +18,8 @@ You can:
 * Run common command-line tools such as `grep`, `sed`, `awk`, or other ELF-64 binaries.
 * Run Bash shell scripts and GNU/Linux command-line applications including:  
     * Tools: vim, emacs, tmux
-    *Languages: [NodeJS](https://docs.microsoft.com/windows/nodejs/setup-on-wsl2), Javascript, [Python](https://docs.microsoft.com/windows/python/web-frameworks), Ruby, C/C++, C# & F#, Rust, Go, etc.
-    *Services: SSHD, MySQL, Apache, lighttpd, [MongoDB](https://docs.microsoft.com/windows/nodejs/databases), [PostgreSQL](https://docs.microsoft.com/windows/python/databases).
+    * Languages: [NodeJS](https://docs.microsoft.com/windows/nodejs/setup-on-wsl2), Javascript, [Python](https://docs.microsoft.com/windows/python/web-frameworks), Ruby, C/C++, C# & F#, Rust, Go, etc.
+    * Services: SSHD, MySQL, Apache, lighttpd, [MongoDB](https://docs.microsoft.com/windows/nodejs/databases), [PostgreSQL](https://docs.microsoft.com/windows/python/databases).
 * Install additional software using own GNU/Linux distribution package manager.
 * Invoke Windows applications using a Unix-like command-line shell.
 * Invoke GNU/Linux applications on Windows.


### PR DESCRIPTION
These were missing spaces and weren't getting displayed correctly in the docs website.