### PR TITLE
Removed dead link in the build-custom-distro.md file

### DIFF
--- a/WSL/build-custom-distro.md
+++ b/WSL/build-custom-distro.md
@@ -41,4 +41,3 @@ Follow the instructions on the [Distro Launcher GitHub repo](https://github.com/
 
 - [Distro Launcher GitHub repo](https://github.com/Microsoft/WSL-DistroLauncher)
 - [GitHub issue tracker for WSL](https://github.com/Microsoft/BashOnWindows/issues)
-- [Command-line UserVoice portal](https://wpdev.uservoice.com/forums/266908-command-prompt-console-bash-on-ubuntu-on-windo/category/161892-bash)


### PR DESCRIPTION
The removed link ("Command-line UserVoice portal") leads to a 404 page that says: "This UserVoice instance is no longer available."