### PR TITLE
Make some steps more visible

### DIFF
--- a/WSL/compare-versions.md
+++ b/WSL/compare-versions.md
@@ -128,9 +128,10 @@ The picture below shows an example of this by connecting to a Node.js server usi
 ### Accessing Windows networking apps from Linux (host IP)
 
 If you want to access a networking app running on Windows (for example an app running on a NodeJS or SQL server) from your Linux distribution (ie Ubuntu), then you need to use the IP address of your host machine. While this is not a common scenario, you can follow these steps to make it work.
-    - Obtain the IP address of your host machine by running this command from your Linux distribution: `cat /etc/resolv.conf`
-    - Copy the IP address following the term: `nameserver`.
-    - Connect to any Windows server using the copied IP address.
+
+1. Obtain the IP address of your host machine by running this command from your Linux distribution: `cat /etc/resolv.conf`
+2. Copy the IP address following the term: `nameserver`.
+3. Connect to any Windows server using the copied IP address.
 
 The picture below shows an example of this by connecting to a Node.js server running in Windows via curl.
 


### PR DESCRIPTION
Currently the steps in the [Accessing Windows networking apps from Linux (host IP)](https://docs.microsoft.com/en-us/windows/wsl/compare-versions#accessing-windows-networking-apps-from-linux-host-ip) paragraph of [Comparing WSL 2 and WSL 1](https://docs.microsoft.com/en-us/windows/wsl/compare-versions#understanding-wsl-2-uses-a-vhd-and-what-to-do-if-you-reach-its-max-size) page are rendered inline which makes it hard to read them:
![image](https://user-images.githubusercontent.com/12630412/97156119-d0cd6b80-17a8-11eb-9b62-c2dfed8ab6d1.png)

The change makes them render on separate lines.