### PR TITLE
Remove description about ver command

### DIFF
--- a/WSL/install-win10.md
+++ b/WSL/install-win10.md
@@ -75,7 +75,7 @@ To update to WSL 2, you must be running Windows 10.
 - For ARM64 systems: **Version 2004** or higher, with **Build 19041** or higher.
 - Builds lower than 18362 do not support WSL 2. Use the [Windows Update Assistant](https://www.microsoft.com/software-download/windows10) to update your version of Windows.
 
-To check your version and build number, select **Windows logo key + R**, type **winver**, select **OK**. (Or enter the `ver` command in Windows Command Prompt). [Update to the latest Windows version](ms-settings:windowsupdate) in the Settings menu.
+To check your version and build number, select **Windows logo key + R**, type **winver**, select **OK**. [Update to the latest Windows version](ms-settings:windowsupdate) in the Settings menu.
 
 > [!NOTE]
 > If you are running Windows 10 version 1903 or 1909, open "Settings" from your Windows menu, navigate to "Update & Security" and select "Check for Updates". Your Build number must be 18362.1049+ or 18363.1049+, with the minor build # over .1049. Read more: [WSL 2 Support is coming to Windows 10 Versions 1903 and 1909](https://devblogs.microsoft.com/commandline/wsl-2-support-is-coming-to-windows-10-versions-1903-and-1909/). See the [troubleshooting instructions](./troubleshooting.md#im-on-windows-10-version-1903-and-i-still-do-not-see-options-for-wsl-2).


### PR DESCRIPTION
> To check your version and build number, select Windows logo key + R, type winver, select OK. (Or enter the ver command in Windows Command Prompt).

The `ver` command in Windows Command Prompt actually does not show necessary version number (Release ID).
```
> ver

Microsoft Windows [Version 10.0.19041.746]
```

To check Release ID in command line, you need the following command in PowerShell:
> PS > (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").ReleaseId

It's awkward and it's easier to use `winver`. I suggest to remove the description about `ver` command.