### PR TITLE
Improve mount limitations documentation

### DIFF
--- a/WSL/wsl2-mount-disk.md
+++ b/WSL/wsl2-mount-disk.md
@@ -2,7 +2,7 @@
 title: Get started mounting a Linux disk in WSL 2 (preview)
 description: Learn how to set up a disk mount in WSL 2 and how to access it.
 keywords: wsl, windows, windowssubsystem, gnu, linux, bash, disk, ext4, filesystem, mount
-ms.date: 11/04/2020
+ms.date: 04/08/2021
 ms.topic: article
 ms.localizationpriority: medium
 ---

--- a/WSL/wsl2-mount-disk.md
+++ b/WSL/wsl2-mount-disk.md
@@ -16,6 +16,7 @@ This tutorial will cover the steps to identify the disk and partition to attach 
 > [!NOTE]
 > You will need to be on Windows 10 Build 20211 or higher to access this feature. You can join the [Windows Insiders Program](https://insider.windows.com/) to get the latest preview builds.
 > Administrator access is required to attach a disk to WSL 2.
+> WSL 2 `mount` command does not support mounting disk (or partitions belong to a disk) that is currently in use (You can't mount a partition from the same disk as Windows).
 
 ## Identify the disk
 

--- a/WSL/wsl2-mount-disk.md
+++ b/WSL/wsl2-mount-disk.md
@@ -9,14 +9,15 @@ ms.localizationpriority: medium
 
 # Get started mounting a Linux disk in WSL 2 (preview)
 
-If you want to access a Linux disk format that isn't supported by Windows, you can use WSL 2 to mount your disk and access its content.
-
-This tutorial will cover the steps to identify the disk and partition to attach to WSL2, how to mount them, and how to access them.
+If you want to access a Linux disk format that isn't supported by Windows, you can use WSL 2 to mount your disk and access its content. This tutorial will cover the steps to identify the disk and partition to attach to WSL2, how to mount them, and how to access them.
 
 > [!NOTE]
-> You will need to be on Windows 10 Build 20211 or higher to access this feature. You can join the [Windows Insiders Program](https://insider.windows.com/) to get the latest preview builds.
 > Administrator access is required to attach a disk to WSL 2.
-> WSL 2 `mount` command does not support mounting disk (or partitions belong to a disk) that is currently in use (You can't mount a partition from the same disk as Windows).
+> The WSL 2 `mount` command does not support mounting a disk (or partitions that belong to the disk) that is currently in use. `wsl --mount` always attaches the entire disk even if only a partition is requested. You can't mount the Windows installation disk.
+
+## Prerequisites
+
+You will need to be on Windows 10 Build 20211 or higher to access this feature. You can join the [Windows Insiders Program](https://insider.windows.com/) to get the latest preview builds.
 
 ## Identify the disk
 


### PR DESCRIPTION
Mounting disk or partitions belonging to a disk that is already in use is not an option and is the cause of several issues: #5997 #6015.

This patch updates the documentation to inform about the limitations of the command, preventing future users from discovering this too late.