### PR TITLE
Add SD cards to the list of wsl --mount limitations

### DIFF
--- a/WSL/wsl2-mount-disk.md
+++ b/WSL/wsl2-mount-disk.md
@@ -181,6 +181,6 @@ You can also use this technique to mount and interact with the virtual hard disk
 
 - At this time, only entire disks can be attached to WSL 2, meaning that it's not possible to attach only a partition. Concretely, this means that it's not possible to use `wsl --mount` to read a partition on the boot device, because that device can't be detached from Windows.
 
-- USB flash drives are not supported at this time and will fail to attach to WSL 2. USB disks are supported though.
+- USB flash drives and SD cards are not supported at this time and will fail to attach to WSL 2. USB disks are supported though.
 
 - Only filesystems that are natively supported in the kernel can be mounted by `wsl --mount`. This means that it's not possible to use installed filesystem drivers (such as ntfs-3g for example) by calling `wsl --mount`.


### PR DESCRIPTION
This change adds a mention that SD cards aren't supported by `wsl --mount` 