### PR TITLE
add additional cause of error 0x80370102 - CPU does not support SLAT

### DIFF
--- a/WSL/install-win10.md
+++ b/WSL/install-win10.md
@@ -205,6 +205,7 @@ Below are related errors and suggested fixes. Refer to the [WSL troubleshooting 
 
 - **Installation failed with error 0x80070003 or error 0x80370102**
   - Please make sure that virtualization is enabled inside of your computer's BIOS. The instructions on how to do this will vary from computer to computer, and will most likely be under CPU related options.
+  - WSL2 requires that your CPU supports the Second Level Address Translation (SLAT) feature, which was introduced in Intel Nehalem processors (Intel Core 1st Generation) and AMD Opteron. Older CPUs (such as the Intel Core 2 Duo) will not be able to run WSL2, even if the Virtual Machine Platform is successfully installed. 
 
 - **Error when trying to upgrade: `Invalid command line option: wsl --set-version Ubuntu 2`**
   - Enure that you have the Windows Subsystem for Linux enabled, and that you're using Windows Build version 18362 or higher. To enable WSL run this command in a PowerShell prompt with admin privileges: `Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux`.


### PR DESCRIPTION
The following error can occur if the CPU is old enough to not support SLAT: 

"Error: 0x80370102 The virtual machine could not be started because a required feature is not installed."

The error message itself is not specific to the root issue and I think it would be helpful to list this possible cause here.

References:
https://github.com/microsoft/WSL/issues/4709
https://github.com/MicrosoftDocs/WSL/issues/846