### PR TITLE
Add `case` in the mount option documentation

### DIFF
--- a/WSL/wsl-config.md
+++ b/WSL/wsl-config.md
@@ -282,6 +282,7 @@ Setting different mount options for Windows drives (DrvFs) can control how file 
 |fmask | An octal mask of permissions to exclude for all files | 000
 |dmask | An octal mask of permissions to exclude for all directories | 000
 |metadata | Whether metadata is added to Windows files to support Linux system permissions | disabled
+|case | Which directories are treated as case sensitive, and whether new directories created with WSL will have the flag set. visit [this blog post](https://devblogs.microsoft.com/commandline/per-directory-case-sensitivity-and-wsl/#per-directory-case-sensitivity-in-wsl) for the detailed explanation of the options. | `dir`
 
 **Note:** The permission masks are put through a logical OR operation before being applied to files or directories. 
 

--- a/WSL/wsl-config.md
+++ b/WSL/wsl-config.md
@@ -282,7 +282,7 @@ Setting different mount options for Windows drives (DrvFs) can control how file 
 |fmask | An octal mask of permissions to exclude for all files | 000
 |dmask | An octal mask of permissions to exclude for all directories | 000
 |metadata | Whether metadata is added to Windows files to support Linux system permissions | disabled
-|case | Which directories are treated as case sensitive, and whether new directories created with WSL will have the flag set. visit [this blog post](https://devblogs.microsoft.com/commandline/per-directory-case-sensitivity-and-wsl/#per-directory-case-sensitivity-in-wsl) for the detailed explanation of the options. | `dir`
+|case | Determines directories treated as case sensitive and whether new directories created with WSL will have the flag set. See [Per-directory case sensitivity and WSL](https://devblogs.microsoft.com/commandline/per-directory-case-sensitivity-and-wsl/#per-directory-case-sensitivity-in-wsl) for a detailed explanation of the options. | `dir`
 
 **Note:** The permission masks are put through a logical OR operation before being applied to files or directories. 
 


### PR DESCRIPTION
`case` option is available (Ref: https://devblogs.microsoft.com/commandline/per-directory-case-sensitivity-and-wsl/) for DrvFs but it is not documented in the mount options section here(https://docs.microsoft.com/en-us/windows/wsl/wsl-config#mount-options)