### PR TITLE
Remove Ubuntu 16.04 as no longer available

### DIFF
--- a/WSL/install-win10.md
+++ b/WSL/install-win10.md
@@ -126,7 +126,6 @@ wsl --set-default-version 2
 
     The following links will open the Microsoft store page for each distribution:
 
-    - [Ubuntu 16.04 LTS](https://www.microsoft.com/store/apps/9pjn388hp8c9)
     - [Ubuntu 18.04 LTS](https://www.microsoft.com/store/apps/9N9TNGVNDL3Q)
     - [Ubuntu 20.04 LTS](https://www.microsoft.com/store/apps/9n6svws3rx71)
     - [openSUSE Leap 15.1](https://www.microsoft.com/store/apps/9NJFZK00FGKV)


### PR DESCRIPTION
Remove the link to Ubuntu 16.04 Windows Store item as it has been removed. I've left the direct link to the appx package as is still working, though I'm not sure I'd recommend 16.04 at this point as it will be EOL as of tomorrow. Can remove as part of this PR if people deem necessary.

Resolves issue #1172