### PR TITLE
Links: WSL (2021-05)

### DIFF
--- a/WSL/compare-versions.md
+++ b/WSL/compare-versions.md
@@ -99,7 +99,7 @@ We recommend that you use WSL 2 as it offers faster performance and 100% system 
 - A project which requires cross-compilation using both Windows and Linux tools on the same files.
   - File performance across the Windows and Linux operating systems is faster in WSL 1 than WSL 2, so if you are using Windows applications to access Linux files, you will currently achieve faster performance with WSL 1.
 - Your project needs access to a serial port or USB device.
-   - According to the [WSL 2 FAQ](https://docs.microsoft.com/windows/wsl/wsl2-faq#can-i-access-the-gpu-in-wsl-2-are-there-plans-to-increase-hardware-support), WSL 2 does not include support for accessing serial ports. The [open issue on serial support](https://github.com/microsoft/WSL/issues/4322) indicates that support has not been added yet.
+   - According to the [WSL 2 FAQ](./wsl2-faq.yml#can-i-access-the-gpu-in-wsl-2-are-there-plans-to-increase-hardware-support), WSL 2 does not include support for accessing serial ports. The [open issue on serial support](https://github.com/microsoft/WSL/issues/4322) indicates that support has not been added yet.
 - You have strict memory requirements
   - WSL 2's memory usage grows and shrinks as you use it. When a process frees memory this is automatically returned to Windows. However, as of right now WSL 2 does not yet release cached pages in memory back to Windows until the WSL instance is shut down. If you have long running WSL sessions, or access a very large amount of files, this cache can take up memory on Windows. We are tracking the work to improve this experience on [the WSL Github repository issue 4166](https://github.com/microsoft/WSL/issues/4166).
 

--- a/WSL/compare-versions.md
+++ b/WSL/compare-versions.md
@@ -99,7 +99,7 @@ We recommend that you use WSL 2 as it offers faster performance and 100% system 
 - A project which requires cross-compilation using both Windows and Linux tools on the same files.
   - File performance across the Windows and Linux operating systems is faster in WSL 1 than WSL 2, so if you are using Windows applications to access Linux files, you will currently achieve faster performance with WSL 1.
 - Your project needs access to a serial port or USB device.
-   - According to the [WSL 2 FAQ](./wsl2-faq.yml#can-i-access-the-gpu-in-wsl-2-are-there-plans-to-increase-hardware-support), WSL 2 does not include support for accessing serial ports. The [open issue on serial support](https://github.com/microsoft/WSL/issues/4322) indicates that support has not been added yet.
+   - According to the [WSL 2 FAQ](./wsl2-faq.yml#can-i-access-the-gpu-in-wsl-2--are-there-plans-to-increase-hardware-support-), WSL 2 does not include support for accessing serial ports. The [open issue on serial support](https://github.com/microsoft/WSL/issues/4322) indicates that support has not been added yet.
 - You have strict memory requirements
   - WSL 2's memory usage grows and shrinks as you use it. When a process frees memory this is automatically returned to Windows. However, as of right now WSL 2 does not yet release cached pages in memory back to Windows until the WSL instance is shut down. If you have long running WSL sessions, or access a very large amount of files, this cache can take up memory on Windows. We are tracking the work to improve this experience on [the WSL Github repository issue 4166](https://github.com/microsoft/WSL/issues/4166).
 

--- a/WSL/faq.yml
+++ b/WSL/faq.yml
@@ -177,7 +177,7 @@ sections:
             lxrun /uninstall /full
             ```
             
-          WSL distributions installed from the store can be uninstalled like any other Windows app, by right-clicking on the app tile and clicking Uninstall, or via PowerShell using the [`Remove-AppxPackage` cmdlet](https://docs.microsoft.com/powershell/module/appx/remove-appxpackage)).
+          WSL distributions installed from the store can be uninstalled like any other Windows app, by right-clicking on the app tile and clicking Uninstall, or via PowerShell using the [`Remove-AppxPackage` cmdlet](/powershell/module/appx/remove-appxpackage)).
           
       - question: |
          Why does ping generate permission denied errors?

--- a/WSL/wsl2-faq.yml
+++ b/WSL/wsl2-faq.yml
@@ -32,7 +32,7 @@ sections:
         answer: |
           Some 3rd party applications cannot work when Hyper-V is in use, which means they will not be able to run when WSL 2 is enabled, such as VMware and VirtualBox. However, recently both VirtualBox and VMware have released versions that support Hyper-V and WSL2. Learn more about [VirtualBox's changes here](https://www.virtualbox.org/wiki/Changelog-6.0) and [VMware's changes here](https://blogs.vmware.com/workstation/2020/01/vmware-workstation-tech-preview-20h1.html). For troubleshooting issues, take a look at the [VirtualBox issue discussions in the WSL repo on GitHub](https://github.com/MicrosoftDocs/WSL/issues?q=is%3Aissue+virtualbox+sort%3Acomments-desc).
           
-          We are consistently working on solutions to support third-party integration of Hyper-V. For example, we expose a set of APIs called [Hypervisor Platform](https://docs.microsoft.com/en-us/virtualization/api/) that third-party virtualization providers can use to make their software compatible with Hyper-V. This lets applications use the Hyper-V architecture for their emulation such as [the Google Android Emulator](https://devblogs.microsoft.com/visualstudio/hyper-v-android-emulator-support/), and VirtualBox 6 and above which are both now compatible with Hyper-V.
+          We are consistently working on solutions to support third-party integration of Hyper-V. For example, we expose a set of APIs called [Hypervisor Platform](/virtualization/api/) that third-party virtualization providers can use to make their software compatible with Hyper-V. This lets applications use the Hyper-V architecture for their emulation such as [the Google Android Emulator](https://devblogs.microsoft.com/visualstudio/hyper-v-android-emulator-support/), and VirtualBox 6 and above which are both now compatible with Hyper-V.
           
       - question: |
           Can I access the GPU in WSL 2? Are there plans to increase hardware support?
@@ -62,4 +62,3 @@ sections:
            [2]: https://docs.microsoft.com/virtualization/api/
            [3]: https://devblogs.microsoft.com/visualstudio/hyper-v-android-emulator-support/
            [4]: https://blogs.vmware.com/workstation/2020/01/vmware-workstation-tech-preview-20h1.html
-          


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to cleanup links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes:

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN).
- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes).

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order:

```
By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments.
```