### PR TITLE
Clarified ICS service hardening sentence and updated link.

### DIFF
--- a/WSL/troubleshooting.md
+++ b/WSL/troubleshooting.md
@@ -395,4 +395,4 @@ Disabling the ICS service (SharedAccess) or disabling ICS through group policy w
 There are no more endpoints available from the endpoint mapper.
 ```
 
-Systems that require WSL 2 should leave the ICS service (SharedAccess) in it's default start state, Manual (Trigger Start), and any policy that disables ICS should be overwritten or removed. We do not recommend disabling ICS, however it can be disabled [using these instructions](./windows/security/threat-protection/microsoft-defender-application-guard/faq-md-app-guard#how-can-i-disable-portions-of-ics-without-breaking-application-guard)
+Systems that require WSL 2 should leave the ICS service (SharedAccess) in it's default start state, Manual (Trigger Start), and any policy that disables ICS should be overwritten or removed. While disabling the ICS service will break WSL2, portions of ICS can be safely disabled to harden the service [using these instructions](windows/security/threat-protection/microsoft-defender-application-guard/faq-md-app-guard#how-can-i-disable-portions-of-ics-without-breaking-application-guard-)

--- a/WSL/troubleshooting.md
+++ b/WSL/troubleshooting.md
@@ -395,4 +395,4 @@ Disabling the ICS service (SharedAccess) or disabling ICS through group policy w
 There are no more endpoints available from the endpoint mapper.
 ```
 
-Systems that require WSL 2 should leave the ICS service (SharedAccess) in it's default start state, Manual (Trigger Start), and any policy that disables ICS should be overwritten or removed. While disabling the ICS service will break WSL2, portions of ICS can be safely disabled to harden the service [using these instructions](windows/security/threat-protection/microsoft-defender-application-guard/faq-md-app-guard#how-can-i-disable-portions-of-ics-without-breaking-application-guard-)
+Systems that require WSL 2 should leave the ICS service (SharedAccess) in it's default start state, Manual (Trigger Start), and any policy that disables ICS should be overwritten or removed. While disabling the ICS service will break WSL 2, and we do not recommend disabling ICS, portions of ICS can be disabled [using these instructions](windows/security/threat-protection/microsoft-defender-application-guard/faq-md-app-guard#how-can-i-disable-portions-of-ics-without-breaking-application-guard-)


### PR DESCRIPTION
The link was missing a trailing hyphen.