### PR TITLE
Update list of "In Preview Options" in .wslconfig

### DIFF
--- a/WSL/wsl-config.md
+++ b/WSL/wsl-config.md
@@ -372,5 +372,7 @@ These options are only available in the latest preview builds if you are on the 
 
 | key | value | default | notes|
 |:----|:----|:----|:----|
-| guiApplications | boolean | `true` | Boolean to turn on or off support for GUI applications(WSLg) in WSL. |
-| debugConsole | boolean | `false` | Boolean to turn on an output console Window that shows the contents of `dmesg` upon start of a WSL 2 distro instance.
+| guiApplications | boolean | `true` | Boolean to turn on or off support for GUI applications ([WSLg](https://github.com/microsoft/wslg)) in WSL. |
+| debugConsole | boolean | `false` | Boolean to turn on an output console Window that shows the contents of `dmesg` upon start of a WSL 2 distro instance. |
+| nestedVirtualization | boolean | `true` | Boolean to turn on or off nested virtualization for WSL2. |
+| vmIdleTimeout | number | `60000` | The number of milliseconds that a VM is idle, before it is shut down. |


### PR DESCRIPTION
Add the `nestedVirtualization` and `vmIdleTimeout` options from Insider builds [20175](https://docs.microsoft.com/en-us/windows/wsl/release-notes#build-20175) and [20190](https://docs.microsoft.com/en-us/windows/wsl/release-notes#build-20190) respectively