### PR TITLE
Remove ~ path segment from command to run Mongo instance

### DIFF
--- a/WSL/tutorials/wsl-database.md
+++ b/WSL/tutorials/wsl-database.md
@@ -122,7 +122,7 @@ To install MongoDB (version 5.0) on WSL (Ubuntu 20.04):
 7. Confirm installation and get the version number: `mongod --version`
 8. Go to your home directory: `cd / && cd home`
 9. Make a directory to store data: `mkdir -p data/db`
-10. Run a Mongo instance: `sudo mongod --dbpath ~/data/db`
+10. Run a Mongo instance: `sudo mongod --dbpath data/db`
 11. Check to see that your MongoDB instance is running with: `ps -e | grep 'mongod'`
 12. To exit the MongoDB Shell, use the shortcut keys: Ctrl + C
 


### PR DESCRIPTION
We were creating `data/db` in `/home` but then tried to run the instance with path `~/data/db` which failed as
`home/accountname/data/db`  did not exist 

```
9. Make a directory to store data: `mkdir -p data/db`
10. Run a Mongo instance: `sudo mongod --dbpath ~/data/db`
```
This pr changes the command to run instance with home path.