### PR TITLE
Fixed typos in various pages

### DIFF
--- a/WSL/file-permissions.md
+++ b/WSL/file-permissions.md
@@ -61,7 +61,7 @@ Chmod will only have one effect, if you remove all the write attributes of a fil
 
 Chmod will change or add metadata depending on the file's already existing metadata. 
 
-Please keep in mind that you cannot give yourself more access than what you have on Windows, even if the metadata says that is the case. For example, you could set the metadata to display that you have write permissions to a file using `chmod 777`, but if you tried to access that file you would still not be able to write to it. This is thanks to interopability, as any read or write commands to Windows files are routed through your Windows user permissions.
+Please keep in mind that you cannot give yourself more access than what you have on Windows, even if the metadata says that is the case. For example, you could set the metadata to display that you have write permissions to a file using `chmod 777`, but if you tried to access that file you would still not be able to write to it. This is thanks to interoperability, as any read or write commands to Windows files are routed through your Windows user permissions.
 
 #### Creating a file in DriveFS
 

--- a/WSL/reference.md
+++ b/WSL/reference.md
@@ -186,5 +186,5 @@ The command `lxrun.exe` can be used to interact with the Windows Subsystem for L
 | `lxrun`                     | The lxrun command is used to manage the WSL instance. |
 | `lxrun /install`            | Starts the download and install process. <br/> **/y** may be added to bypass all prompts.  The confirmation prompt is automatically accepted and the default user is set to root.          |
 | `lxrun /uninstall`          | Uninstalls and deletes the Ubuntu image.  By default this does not remove the user's Ubuntu home directory. <br/> **/y** may be added to automatically accept the confirmation prompt <br/>**/full** uninstalls and deletes the user's Ubuntu home directory         |
-| `lxrun /setdefaultuser <userName>`     | Sets the default Bash on Ubuntu user. Will prompt for a password if the specified user does not exist.  For more information visit: https://aka.ms/wslusers. <br/> **/y** Bypasses promping for the password.  The user will be created without a password.|
+| `lxrun /setdefaultuser <userName>`     | Sets the default Bash on Ubuntu user. Will prompt for a password if the specified user does not exist.  For more information visit: https://aka.ms/wslusers. <br/> **/y** Bypasses prompting for the password.  The user will be created without a password.|
 | `lxrun /update`            | Updates the subsystem's package index          |

--- a/WSL/setup/environment.md
+++ b/WSL/setup/environment.md
@@ -152,7 +152,7 @@ Follow this step-by-step guide to [Get started mounting a Linux disk in WSL 2](.
 
 ## Additional resources
 
-- [Set up your development environment on Windows](/windows/dev-environment/): Learn more about setting up your developerment environment for your preferred language or framework, such as React, Python, NodeJS, Vue, etc.
+- [Set up your development environment on Windows](/windows/dev-environment/): Learn more about setting up your development environment for your preferred language or framework, such as React, Python, NodeJS, Vue, etc.
 - [Troubleshooting](../troubleshooting.md): Find common issues, where to report bugs, where to request new features, and how to contribute to the docs.
 - [FAQs](../faq.yml): Find a list of frequently asked questions. You can also find [FAQs specifically about WSL 2](../wsl2-faq.yml).
 - [Release Notes](../release-notes.md): Review the WSL Release Notes for a history of past build updates. You can also find the [release notes for the WSL Linux Kernel](../kernel-release-notes.md). 

--- a/WSL/troubleshooting.md
+++ b/WSL/troubleshooting.md
@@ -397,4 +397,4 @@ Disabling the ICS service (SharedAccess) or disabling ICS through group policy w
 There are no more endpoints available from the endpoint mapper.
 ```
 
-Systems that require WSL 2 should leave the ICS service (SharedAccess) in it's default start state, Manual (Trigger Start), and any policy that disables ICS should be overwritten or removed. While disabling the ICS service will break WSL 2, and we do not recommend disabling ICS, portions of ICS can be disabled [using these instructions](windows/security/threat-protection/microsoft-defender-application-guard/faq-md-app-guard#how-can-i-disable-portions-of-ics-without-breaking-application-guard-)
+Systems that require WSL 2 should leave the ICS service (SharedAccess) in it's default start state, Manual (Trigger Start), and any policy that disables ICS should be overwritten or removed. While disabling the ICS service will break WSL 2, and we do not recommend disabling ICS, portions of ICS can be disabled [using these instructions](../security/threat-protection/microsoft-defender-application-guard/faq-md-app-guard#how-can-i-disable-portions-of-ics-without-breaking-application-guard-)

--- a/WSL/troubleshooting.md
+++ b/WSL/troubleshooting.md
@@ -63,7 +63,7 @@ For more information, please refer to issue [5749](https://github.com/microsoft/
 
 A 9p protocol file server provides the service on the Linux side to allow Windows to access the Linux file system. If you cannot access WSL using `\\wsl$` on Windows, it could be because 9P did not start correctly.
 
-To check this, you can check the start up logs using: `dmesg |grep 9p`, and this will show you any errors. A successfull output looks like the following:
+To check this, you can check the start up logs using: `dmesg |grep 9p`, and this will show you any errors. A successful output looks like the following:
 
 ```bash
 [    0.363323] 9p: Installing v9fs 9p2000 file system support


### PR DESCRIPTION
[environment.md ](https://github.com/MicrosoftDocs/WSL/blob/master/WSL/setup/environment.md):
- Changed `developerment` to `development`

[file-permissions.md](https://github.com/MicrosoftDocs/WSL/blob/master/WSL/file-permissions.md):
 - Changed `interopability` to `interoperability`
 
[reference.md](https://github.com/MicrosoftDocs/WSL/blob/master/WSL/reference.md):
 - Changed `promping` to `prompting`
 
[troubleshooting.md](https://github.com/MicrosoftDocs/WSL/blob/master/WSL/troubleshooting.md):
- Changed `successfull` to `successful`
- Fixed broken link to disabling ICS instructions