### PR TITLE
fix: Typo in WSL full name. #1381 

### DIFF
--- a/WSL/store-release-notes.md
+++ b/WSL/store-release-notes.md
@@ -12,5 +12,5 @@ ms.localizationpriority: high
 The release notes for [WSL inside of the Microsoft Store](https://aka.ms/wslstorepage) can be found on the [Microsoft/WSL Github repository releases page](https://github.com/microsoft/WSL/releases). Please see that list for latest updates.
 
 ## Known Issues:
-* Launching Windows Subsystem from Linux from session zero does not currently work (for example from an ssh connection).
+* Launching Windows Subsystem for Linux from session zero does not currently work (for example from an ssh connection).
 * The Linux icon in Windows Explorer will only appear if you have the Windows Subsystem for Linux Optional Component installed.


### PR DESCRIPTION
Closes issue  #1381 

It seems the full form of WSL was written wrongly as Windows Subsystem **from** Linux
when it should be  Windows Subsystem **for** Linux.

Very subtle but can be confusing for new documentation readers/ new WSL users.