### PR TITLE
Bulk fix - Removing .localizationpriority

### DIFF
--- a/WSL/about.md
+++ b/WSL/about.md
@@ -5,7 +5,6 @@ keywords: BashOnWindows, bash, wsl, windows, windowssubsystem, gnu, linux
 ms.date: 09/27/2021
 ms.topic: article
 ms.assetid: 3cefe0db-7616-4848-a2b6-9296746a178b
-ms.localizationpriority: high
 ---
 
 # What is the Windows Subsystem for Linux?

--- a/WSL/basic-commands.md
+++ b/WSL/basic-commands.md
@@ -3,7 +3,6 @@ title: Basic commands for WSL
 description: Reference for the basic commands included with Windows Subsystem for Linux (WSL).
 ms.date: 11/23/2021
 ms.topic: article
-ms.localizationpriority: high
 ---
 
 # Basic commands for WSL

--- a/WSL/case-sensitivity.md
+++ b/WSL/case-sensitivity.md
@@ -4,7 +4,6 @@ description: Learn how case sensitive file names are handled between Windows and
 keywords: case sensitivity, wsl, windows, linux, ntfs, mount
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: medium
 ---
 
 # Adjust case sensitivity

--- a/WSL/compare-versions.md
+++ b/WSL/compare-versions.md
@@ -4,7 +4,6 @@ description: WSL 2 provides the benefits of WSL 1, but uses an actual Linux kern
 ms.date: 11/22/2021
 ms.topic: conceptual
 ms.custom: seo-windows-dev
-ms.localizationpriority: high
 ---
 
 # Comparing WSL 1 and WSL 2

--- a/WSL/connect-usb.md
+++ b/WSL/connect-usb.md
@@ -3,7 +3,6 @@ title: Connect USB devices
 description: Learn how to connect a USB device to your WSL 2 Linux distribution using usbipd-win.
 ms.date: 11/09/2021
 ms.topic: article
-ms.localizationpriority: medium
 ---
 
 # Connect USB devices

--- a/WSL/file-permissions.md
+++ b/WSL/file-permissions.md
@@ -4,7 +4,6 @@ description: Understanding how WSL determines file permissions in Windows
 keywords: File permissions, bash, wsl, wsl2, windows, windows subsystem for linux, windows subsystem, ubuntu, debian, suse, windows 10
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: high
 ---
 
 # File Permissions for WSL

--- a/WSL/filesystems.md
+++ b/WSL/filesystems.md
@@ -4,7 +4,6 @@ description: Learn about the considerations and interop commands available when 
 keywords: wsl, Linux, Windows, file systems, interop, across directories, mnt
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: high
 ---
 
 # Working across Windows and Linux file systems

--- a/WSL/index.md
+++ b/WSL/index.md
@@ -3,7 +3,6 @@ title: Windows Subsystem for Linux Documentation
 description: Overview of the Windows Subsystem for Linux documentation.
 ms.topic: overview
 ms.date: 12/06/2021
-ms.localizationpriority: high
 ms.custom: seo-windows-dev
 ---
 

--- a/WSL/install-manual.md
+++ b/WSL/install-manual.md
@@ -4,7 +4,6 @@ description: Step by step instructions to manually install WSL on older versions
 keywords: wsl, install, BashOnWindows, bash, windows subsystem for linux, install ubuntu on windows, enable WSL2, linux on windows
 ms.date: 11/12/2021
 ms.topic: article
-ms.localizationpriority: high
 ---
 
 # Manual installation steps for older versions of WSL

--- a/WSL/install-on-server.md
+++ b/WSL/install-on-server.md
@@ -3,7 +3,6 @@ title: Install Linux Subsystem on Windows Server
 description: Learn how to install the Linux Subsystem on Windows Server. WSL is available for installation on Windows Server 2019 (version 1709) and later.
 ms.date: 11/12/2021
 ms.topic: article
-ms.localizationpriority: high
 ---
 
 # Windows Server Installation Guide

--- a/WSL/install.md
+++ b/WSL/install.md
@@ -3,7 +3,6 @@ title: Install WSL
 description: Install Windows Subsystem for Linux with the command, wsl --install. Use a Bash terminal on your Windows machine run by your preferred Linux distribution - Ubuntu, Debian, SUSE, Kali, Fedora, Pengwin, Alpine, and more are available.
 ms.date: 11/22/2021
 ms.topic: article
-ms.localizationpriority: high
 ---
 
 # Install WSL

--- a/WSL/kernel-release-notes.md
+++ b/WSL/kernel-release-notes.md
@@ -4,7 +4,6 @@ description: Release notes for the Windows Subsystem for Linux.  Updated monthly
 keywords: release notes, wsl, windows, windows subsystem for linux, windowssubsystem, ubuntu, kernel
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: high
 ---
 
 # Release Notes for Windows Subsystem for Linux kernel

--- a/WSL/networking.md
+++ b/WSL/networking.md
@@ -4,7 +4,6 @@ description: Learn about the considerations for accessing network applications w
 keywords: wsl, Linux, Windows, networking, ip address, ip addr, host IP, server, network, localhost, local area network, lan, ipv6, remote
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: high
 ---
 
 # Accessing network applications with WSL

--- a/WSL/release-notes.md
+++ b/WSL/release-notes.md
@@ -5,7 +5,6 @@ keywords: release notes, wsl, windows, windows subsystem for linux, windowssubsy
 author: benhillis
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: high
 ---
 
 # Release Notes for Windows Subsystem for Linux

--- a/WSL/setup/environment.md
+++ b/WSL/setup/environment.md
@@ -3,7 +3,6 @@ title: Set up a WSL development environment
 description: Set up a WSL development environment using best practices from this set-by-step guide. Learn how to run Ubuntu, Visual Studio Code or Visual Studio, Git, Windows Credential Manager, MongoDB, MySQL, Docker remote containers and more.
 ms.date: 12/06/2021
 ms.topic: article
-ms.localizationpriority: medium
 no-loc: [Terminal]
 ms.custom: seo-windows-dev
 ---

--- a/WSL/store-release-notes.md
+++ b/WSL/store-release-notes.md
@@ -4,7 +4,6 @@ description: Release notes for the Windows Subsystem for Linux
 keywords: release notes, wsl, windows, windows subsystem for linux, windowssubsystem, ubuntu, kernel
 ms.date: 10/11/2021
 ms.topic: article
-ms.localizationpriority: high
 ---
 
 # Release Notes for Windows Subsystem for Linux in the Microsoft Store

--- a/WSL/troubleshooting.md
+++ b/WSL/troubleshooting.md
@@ -4,7 +4,6 @@ description: Provides detailed information about common errors and issues people
 keywords: BashOnWindows, bash, wsl, windows, windowssubsystem, ubuntu
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: high
 ---
 
 # Troubleshooting Windows Subsystem for Linux

--- a/WSL/tutorials/gpu-compute.md
+++ b/WSL/tutorials/gpu-compute.md
@@ -4,7 +4,6 @@ description: Learn more about WSL 2 support for NVIDIA CUDA, DirectML, Tensorflo
 keywords: wsl, windows, windows subsystem, gpu compute, gpu acceleration, NVIDIA, CUDA, DirectML, Tensorflow, PyTorch, NVIDIA CUDA preview, GPU driver, NVIDIA Container Toolkit, Docker
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: medium
 ---
 
 # GPU accelerated machine learning training in the Windows Subsystem for Linux

--- a/WSL/tutorials/gui-apps.md
+++ b/WSL/tutorials/gui-apps.md
@@ -4,7 +4,6 @@ description: Learn how WSL support running Linux GUI apps.
 keywords: wsl, windows, windows subsystem for linux, gui apps 
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: medium
 ---
 
 # Run Linux GUI apps on the Windows Subsystem for Linux (preview)

--- a/WSL/tutorials/wsl-containers.md
+++ b/WSL/tutorials/wsl-containers.md
@@ -4,7 +4,6 @@ description: Learn how to set up Docker containers on the Windows Subsystem for 
 keywords: wsl, windows, windowssubsystem, windows 10, docker, containers
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: medium
 ---
 
 # Get started with Docker remote containers on WSL 2

--- a/WSL/tutorials/wsl-database.md
+++ b/WSL/tutorials/wsl-database.md
@@ -4,7 +4,6 @@ description: Learn how to set up MySQL MongoDB, PostgreSQL, SQLite, Microsoft SQ
 keywords: wsl, windows, windowssubsystem, MySQL MongoDB, PostgreSQL, SQLite, Microsoft SQL Server, Redis, windows 10
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: medium
 ---
 
 # Get started with databases on Windows Subsystem for Linux

--- a/WSL/tutorials/wsl-git.md
+++ b/WSL/tutorials/wsl-git.md
@@ -4,7 +4,6 @@ description: Learn how to set up Git for version control on the Windows Subsyste
 keywords: wsl, windows, windowssubsystem, gnu, linux, bash, git, github, version control
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: medium
 ---
 
 # Get started using Git on Windows Subsystem for Linux

--- a/WSL/tutorials/wsl-vscode.md
+++ b/WSL/tutorials/wsl-vscode.md
@@ -4,7 +4,6 @@ description: Learn how to set up VS Code to author and debug code using the Wind
 keywords: wsl, windows, windowssubsystem, gnu, linux, bash, vs code, remote extension, debug, path, visual studio
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: medium
 ---
 
 # Get started using Visual Studio Code with Windows Subsystem for Linux

--- a/WSL/vhd-size.md
+++ b/WSL/vhd-size.md
@@ -4,7 +4,6 @@ description: Learn how to expand the size of the Virtual Hard Disk (VHD) used wi
 keywords: wsl, vhd, size, resize, virtual hard disk, ext4, file system, expand, increase, storage space, diskpart, resize2fs
 ms.date: 09/27/2021
 ms.topic: article
-ms.localizationpriority: high
 ---
 
 # Expand the size of your WSL 2 Virtual Hard Disk

--- a/WSL/wsl2-mount-disk.md
+++ b/WSL/wsl2-mount-disk.md
@@ -3,7 +3,6 @@ title: Get started mounting a Linux disk in WSL 2
 description: Learn how to set up a disk mount in WSL 2 and how to access it.
 ms.date: 11/15/2021
 ms.topic: article
-ms.localizationpriority: medium
 ---
 
 # Mount a Linux disk in WSL 2


### PR DESCRIPTION
This is a bulk fix - According to the new DevRel GX group mission, the Localization production team drives the localization priority and translation quality per customer usage data, e.g. Page View or MAU of the language. The localization priority is defined by the project setting in localization pipeline - ms.localizationpriority in the source file is no longer used as a driving parameter to define the localization priority. https://review.docs.microsoft.com/help/contribute/localization-checklist-for-writer?branch=master#stop-using-mslocalizationpriority-metadata