### PR TITLE
fix: Broken Markdown in breadcrumb navigation

### DIFF
--- a/WSL/install.md
+++ b/WSL/install.md
@@ -12,7 +12,7 @@ ms.topic: article
 You must be running Windows 10 version 2004 and higher (Build 19041 and higher) or Windows 11.
   
 > [!NOTE]
-> To check your Windows version and build number, select **Windows logo key + R**, type **winver**, select **OK**. You can update to the latest Windows version by selecting **Start** > **Settings** > **Windows Update **> **[Check for updates](ms-settings:windowsupdate)**.
+> To check your Windows version and build number, select **Windows logo key + R**, type **winver**, select **OK**. You can update to the latest Windows version by selecting **Start** > **Settings** > **Windows Update ** > **[Check for updates](ms-settings:windowsupdate)**.
 
 If you're running an older build, or just prefer not to use the install command and would like step-by-step directions, see **[WSL manual installation steps for older versions](./install-manual.md)**.
 

--- a/WSL/install.md
+++ b/WSL/install.md
@@ -12,7 +12,7 @@ ms.topic: article
 You must be running Windows 10 version 2004 and higher (Build 19041 and higher) or Windows 11.
   
 > [!NOTE]
-> To check your Windows version and build number, select **Windows logo key + R**, type **winver**, select **OK**. You can update to the latest Windows version by selecting **Start** > **Settings** > **Windows Update ** > **[Check for updates](ms-settings:windowsupdate)**.
+> To check your Windows version and build number, select **Windows logo key + R**, type **winver**, select **OK**. You can update to the latest Windows version by selecting **Start** > **Settings** > **Windows Update** > **[Check for updates](ms-settings:windowsupdate)**.
 
 If you're running an older build, or just prefer not to use the install command and would like step-by-step directions, see **[WSL manual installation steps for older versions](./install-manual.md)**.
 


### PR DESCRIPTION
My fix repairs the currently broken Markdown on https://docs.microsoft.com/en-us/windows/wsl/install:

![image](https://user-images.githubusercontent.com/469989/148643529-94a23698-da81-4650-b204-e0fd9dbd25ce.png)
