### PR TITLE
Update Intel drivers link to latest version

### DIFF
--- a/WSL/tutorials/gui-apps.md
+++ b/WSL/tutorials/gui-apps.md
@@ -31,7 +31,7 @@ You can now integrate both Windows and Linux applications into your workflow for
 
     To run Linux GUI apps, you should first install the preview driver matching your system below. This will enable you to use a virtual GPU (vGPU) so you can benefit from hardware accelerated OpenGL rendering.
 
-  - [**Intel** GPU driver for WSL](https://www.intel.com/content/www/us/en/download/19344/intel-graphics-windows-10-windows-11-dch-drivers.html)
+  - [**Intel** GPU driver for WSL](https://www.intel.com/content/www/us/en/download/19344/intel-graphics-windows-dch-drivers.html)
   - [**AMD** GPU driver for WSL](https://www.amd.com/en/support/kb/release-notes/rn-rad-win-wsl-support)
   - [**NVIDIA** GPU driver for WSL](https://developer.nvidia.com/cuda/wsl)
 


### PR DESCRIPTION
Original Page states: https://www.intel.com/content/www/us/en/download/19344/30579/intel-graphics-windows-dch-drivers.html is version 30.0.100.9684


![image](https://user-images.githubusercontent.com/234704/152798035-309ebdfc-fca2-409f-96bd-b97cb5f52ebe.png)

New page is version: 30.0.101.1191