### PR TITLE
fix: Add bold around **as administrator** required privileges

### DIFF
--- a/WSL/install-manual.md
+++ b/WSL/install-manual.md
@@ -14,7 +14,7 @@ For simplicity, we generally recommend using the [`wsl --install`](./install.md)
 
 You must first enable the "Windows Subsystem for Linux" optional feature before installing any Linux distributions on Windows.
 
-Open PowerShell as Administrator (Start menu > PowerShell > right-click > Run as Administrator) and enter this command:
+Open PowerShell **as Administrator (Start menu > PowerShell > right-click > Run as Administrator)** and enter this command:
 
 ```powershell
 dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart

--- a/WSL/install-on-server.md
+++ b/WSL/install-on-server.md
@@ -13,7 +13,7 @@ The Windows Subsystem for Linux is available for installation on Windows Server 
 
 Before you can run Linux distributions on Windows, you must enable the "Windows Subsystem for Linux" optional feature and reboot.
 
-Open PowerShell as Administrator and run:
+Open PowerShell **as Administrator** and run:
 
 ```powershell
     Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux

--- a/WSL/install.md
+++ b/WSL/install.md
@@ -18,7 +18,7 @@ If you're running an older build, or just prefer not to use the install command 
 
 ## Install
 
-You can now install everything you need to run Windows Subsystem for Linux (WSL) by entering this command in an administrator PowerShell or Windows Command Prompt and then restarting your machine.
+You can now install everything you need to run Windows Subsystem for Linux (WSL) by entering this command in an **administrator** PowerShell or Windows Command Prompt and then restarting your machine.
 
 ```powershell
 wsl --install


### PR DESCRIPTION
Hi,

I noticed that many users (myself included...) launched a regular PowerShell to run `wsl --install` before realizing that it required more privileges because the message about the requirement of launching PowerShell **as administrator** wasn't visible enough.
So I'm proposing to put the information in bold.

Unrelated question : as a French user I'm accessing a French version of the documentation but can't see any i18n files in the repository. Is it done automatically?

Thank you