### PR TITLE
Update git-credential-manager-core path to latest version

### DIFF
--- a/WSL/tutorials/wsl-git.md
+++ b/WSL/tutorials/wsl-git.md
@@ -78,7 +78,7 @@ If you have a reason not to install Git for Windows, you can install GCM as a Li
 To set up GCM for use with a WSL distribution, open your distribution and enter this command:
 
 ```Bash
-git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager-core.exe"
+git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager-core.exe"
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Thank you for good documents. If you have a time please confirm this P-R.

## Overview
- Update command for how to use git-credential-manager on WSL.

## ref
- [git-credential-manager/wsl.md at main · GitCredentialManager/git-credential-manager](https://github.com/GitCredentialManager/git-credential-manager/blob/main/docs/wsl.md#configuring-wsl-with-git-for-windows-recommended)