### PR TITLE
Update docs to reflect GCM new path and avoid errors

### DIFF
--- a/WSL/tutorials/wsl-git.md
+++ b/WSL/tutorials/wsl-git.md
@@ -77,19 +77,14 @@ If you have a reason not to install Git for Windows, you can install GCM as a Li
 
 To set up GCM for use with a WSL distribution, open your distribution and enter this command:
 
-If GIT installed is < v2.36.1
+If GIT installed is >= v2.36.1
 ```Bash
 git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager-core.exe"
 ```
 
-If you have an older installtion of GCM this may be more appropriate:
-
+else if version is < v2.36.1 enter this command: 
 ```Bash
 git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager-core.exe"
-```
-else if version is >= v2.36.1 enter this command: 
-```Bash
-git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager-core.exe"
 ```
 
 > [!NOTE]

--- a/WSL/tutorials/wsl-git.md
+++ b/WSL/tutorials/wsl-git.md
@@ -77,8 +77,13 @@ If you have a reason not to install Git for Windows, you can install GCM as a Li
 
 To set up GCM for use with a WSL distribution, open your distribution and enter this command:
 
+If GIT installed is < v2.36.1
 ```Bash
 git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager-core.exe"
+```
+else if version is >= v2.36.1 enter this command: 
+```Bash
+git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager-core.exe"
 ```
 
 > [!NOTE]


### PR DESCRIPTION
The path to git-credential-manager-core.exe has changed according to this [PR](https://github.com/git-for-windows/build-extra/pull/406) and the comments in the [v2.36.1 release notes](https://github.com/git-for-windows/git/releases/tag/v2.36.1.windows.1)