### PR TITLE
Update wsl-git.md

### DIFF
--- a/WSL/tutorials/wsl-git.md
+++ b/WSL/tutorials/wsl-git.md
@@ -78,7 +78,7 @@ If you have a reason not to install Git for Windows, you can install GCM as a Li
 To set up GCM for use with a WSL distribution, open your distribution and enter this command:
 
 ```Bash
-git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager-core.exe"
+git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-wincred.exe"
 ```
 
 > [!NOTE]


### PR DESCRIPTION
In the last versions of Git "git-credential-manager-core.exe" does not exist. I think it has been renamed to git-credential-wincred.exe