### PR TITLE
Fixed wslconfig value types

### DIFF
--- a/WSL/wsl-config.md
+++ b/WSL/wsl-config.md
@@ -208,13 +208,13 @@ Section label: `[wsl2]`
 
 | key | value | default | notes|
 |:----|:----|:----|:----|
-| kernel | string | The Microsoft built kernel provided inbox | An absolute Windows path to a custom Linux kernel. |
+| kernel | path | The Microsoft built kernel provided inbox | An absolute Windows path to a custom Linux kernel. |
 | memory | size | 50% of total memory on Windows or 8GB, whichever is less; on builds before 20175: 80% of your total memory on Windows | How much memory to assign to the WSL 2 VM. |
 | processors | number | The same number of processors on Windows | How many processors to assign to the WSL 2 VM. |
 | localhostForwarding | boolean | `true` | Boolean specifying if ports bound to wildcard or localhost in the WSL 2 VM should be connectable from the host via `localhost:port`. |
 | kernelCommandLine | string | Blank | Additional kernel command line arguments. |
 | swap | size | 25% of memory size on Windows rounded up to the nearest GB | How much swap space to add to the WSL 2 VM, 0 for no swap file. Swap storage is disk-based RAM used when memory demand exceeds limit on hardware device. |
-| swapFile | string | `%USERPROFILE%\AppData\Local\Temp\swap.vhdx` | An absolute Windows path to the swap virtual hard disk. |
+| swapFile | path | `%USERPROFILE%\AppData\Local\Temp\swap.vhdx` | An absolute Windows path to the swap virtual hard disk. |
 | pageReporting | boolean | `true` | Default `true` setting enables Windows to reclaim unused memory allocated to WSL 2 virtual machine. |
 | guiApplications | boolean* | `true` | Boolean to turn on or off support for GUI applications ([WSLg](https://github.com/microsoft/wslg)) in WSL. Only available for Windows 11.|
 | debugConsole | boolean* | `false` | Boolean to turn on an output console Window that shows the contents of `dmesg` upon start of a WSL 2 distro instance. Only available for Windows 11.|


### PR DESCRIPTION
From my understanding `kernel` and `swapfile` in `.wslconfig` should be of type `path` as they represent Windows paths and are also handled in the example like it is described for the value type `path`.