### PR TITLE
docs: fix the credential helper path

### DIFF
--- a/WSL/tutorials/wsl-git.md
+++ b/WSL/tutorials/wsl-git.md
@@ -84,7 +84,7 @@ git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git
 
 else if version is < v2.36.1 enter this command: 
 ```Bash
-git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager-core.exe"
+git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/libexec/git-core/git-credential-manager.exe"
 ```
 
 > [!NOTE]


### PR DESCRIPTION
When (windows) git version is < 2.3.1 the executable name of the credential helper is `git-credential-manager.exe` instead of `git-credential-manager-core.exe`