### PR TITLE
Fix Windows build number introducing WSL

### DIFF
--- a/WSL/compare-versions.md
+++ b/WSL/compare-versions.md
@@ -35,7 +35,7 @@ Feature | WSL 1 | WSL 2
 
 As you can tell from the comparison table above, the WSL 2 architecture outperforms WSL 1 in several ways, with the exception of performance across OS file systems, which can be addressed by storing your project files on the same operating system as the tools you are running to work on the project.
 
-WSL 2 is only available in Windows 11 or Windows 10, Version 1903, Build 18362 or later. Check your Windows version by selecting the **Windows logo key + R**, type **winver**, select **OK**. (Or enter the `ver` command in Windows Command Prompt). You may need to [update to the latest Windows version](ms-settings:windowsupdate). For builds lower than 18362, WSL is not supported at all.
+WSL 2 is only available in Windows 11 or Windows 10, Version 1903, Build 18362 or later. Check your Windows version by selecting the **Windows logo key + R**, type **winver**, select **OK**. (Or enter the `ver` command in Windows Command Prompt). You may need to [update to the latest Windows version](ms-settings:windowsupdate). For builds lower than 14393, WSL is not supported at all.
 
 > [!NOTE]
 > WSL 2 will work with [VMware 15.5.5+](https://blogs.vmware.com/workstation/2020/05/vmware-workstation-now-supports-hyper-v-mode.html) and [VirtualBox 6+](https://www.virtualbox.org/wiki/Changelog-6.0). Learn more in our [FAQs.](./faq.yml#will-i-be-able-to-run-wsl-2-and-other-3rd-party-virtualization-tools-such-as-vmware--or-virtualbox-)


### PR DESCRIPTION
WSL was initially introduced in 2016, while WSL 2 was introduced in 2019.
ref: https://www.howtogeek.com/248177/whats-new-in-windows-10s-anniversary-update/#:~:text=Windows%20Gets%20Its%20Own%20Linux%20Command%20Line