### PR TITLE
LinkFix: WSL (2022-11)

### DIFF
--- a/WSL/tutorials/linux.md
+++ b/WSL/tutorials/linux.md
@@ -69,7 +69,7 @@ You can create a new file via the ‘touch’ command followed by the name of th
 ```bash
 touch hello_world.txt 
 ```
-You can edit files using any downloaded graphical text-editor or the VS Code Remote – WSL extension. You can learn more about getting started with VS Code [here](https://docs.microsoft.com/windows/wsl/tutorials/wsl-vscode)
+You can edit files using any downloaded graphical text-editor or the VS Code Remote – WSL extension. You can learn more about getting started with VS Code [here](/windows/wsl/tutorials/wsl-vscode)
 
 If you prefer to edit a file directly from the command-line, you’ll need to use a command-line editor such as vim, emacs, or nano. Many distributions come with one or more of these programs installed, but you can always install these programs by following the installation instructions outlined in the guide from [above](https://github.com/MicrosoftDocs/WSL/edit/linux-tutorial/WSL/tutorials/linux.md#installing-and-updating-software). 
 


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 