### PR TITLE
Delete duplicate manual installation instructions, fixes #1660

### DIFF
--- a/WSL/install.md
+++ b/WSL/install.md
@@ -27,8 +27,6 @@ This command will enable the features necessary to run WSL and install the Ubunt
 
 If you're running an older build, or just prefer not to use the install command and would like step-by-step directions, see **[WSL manual installation steps for older versions](./install-manual.md)**.
 
-If you're running an older build, or just prefer not to use the install command and would like step-by-step directions, see **[WSL manual installation steps for older versions](./install-manual.md)**.
-
 The first time you launch a newly installed Linux distribution, a console window will open and you'll be asked to wait for files to de-compress and be stored on your machine. All future launches should take less than a second.
 
 > [!NOTE]


### PR DESCRIPTION
Deleted a duplicate instruction explaining how to get step-by-step instructions for instructions. Fixes Issue #1660 