### PR TITLE
Update wsl-git.md

### DIFF
--- a/WSL/tutorials/wsl-git.md
+++ b/WSL/tutorials/wsl-git.md
@@ -125,7 +125,7 @@ Visual Studio Code comes with built-in support for Git, including a source contr
 
 If you are working with the same repository folder between Windows, WSL, or a container, be sure to set up consistent line endings.
 
-Since Windows and Linux use different default line endings, Git may report a large number of modified files that have no differences aside from their line endings. To prevent this from happening, you can disable line ending conversion using a `.gitattributes` file or globally on the Windows side. See this [VS Code doc about resolving Git line ending issues](https://code.visualstudio.com/docs/remote/troubleshooting#_resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files).
+Since Windows and Linux use different default line endings, Git may report a large number of modified files that have no differences aside from their line endings. To prevent this from happening, you can disable line ending conversion using a `.gitattributes` file or globally on the Windows side. See this [VS Code doc about resolving Git line ending issues](https://code.visualstudio.com/docs/remote/troubleshooting#_resolving-git-line-ending-issues-in-wsl-resulting-in-many-modified-files).
 
 ## Additional resources
 


### PR DESCRIPTION
Fixing link in the [Git line endings](https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git#git-line-endings) section.  URL has been updated from `containers` to `wsl` This update will direct to spesific section 

fix issue: [#1651](https://github.com/MicrosoftDocs/WSL/issues/1651)