### PR TITLE
docs: fix the credential helper path again

### DIFF
--- a/WSL/tutorials/wsl-git.md
+++ b/WSL/tutorials/wsl-git.md
@@ -77,7 +77,12 @@ If you have a reason not to install Git for Windows, you can install GCM as a Li
 
 To set up GCM for use with a WSL distribution, open your distribution and enter this command:
 
-If GIT installed is >= v2.36.1
+If GIT installed is >= v2.39.0
+```Bash
+git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
+```
+
+else if GIT installed is >= v2.36.1
 ```Bash
 git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager-core.exe"
 ```


### PR DESCRIPTION
"Git Credential Manager Core" was renamed to "Git Credential Manager". See: https://aka.ms/gcm/rename

The newest version of Git for Windows (2.39.0) now complains if you use the old binary:
```
$ git push
warning: git-credential-manager-core was renamed to git-credential-manager
warning: see https://aka.ms/gcm/rename for more information
warning: git-credential-manager-core was renamed to git-credential-manager
warning: see https://aka.ms/gcm/rename for more information
Everything up-to-date
```