### PR TITLE
Don't instruct on using exploitable key storage

### DIFF
--- a/WSL/tutorials/gpu-compute.md
+++ b/WSL/tutorials/gpu-compute.md
@@ -39,11 +39,11 @@ This guide will show how to set up:
     ```
     
     ```bash
-    curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
+    curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-docker-keyring.gpg
     ```
     
     ```bash
-    curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+    curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-docker-keyring.gpg] https://#g' | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
     ```
 
     Install the NVIDIA runtime packages and dependencies by running the commands:


### PR DESCRIPTION
The `apt-key add` method for storing signing authorities is deprecated, due to a vulnerability in which an illegitimate package could be signed by the wrong authority, and thus allowed to complete download despite being potentially malicious. See [here](https://wiki.debian.org/DebianRepository/UseThirdParty) for further reading.

This change updates to instead use the recommended keyrings approach, with the `[signed-by=` field to protect against the above exploit. This is the approach NVIDIA already recommends, for example [this installation guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).