### PR TITLE
add the adobe-target metadata for A/B testing

### DIFF
--- a/WSL/docfx.json
+++ b/WSL/docfx.json
@@ -43,7 +43,8 @@
       "author": "craigloewen-msft",
       "ms.author": "crloewen",
       "searchScope": ["WSL"],
-      "feedback_product_url": "https://github.com/Microsoft/WSL/issues"
+      "feedback_product_url": "https://github.com/Microsoft/WSL/issues",
+      "adobe-target": true
     },
     "fileMetadata": {},
     "template": [],


### PR DESCRIPTION
@craigloewen-msft could you please help to merge this metadata change (adobe-target=true) to main branch and then to live? This is to enable A/B testing ability across many url base paths so we can improve Learn user experience based on data-driven decisions. This meta (adobe-target) itself will not change how your content is displayed or modify any other UI behaviors so it is safe to merge.