### PR TITLE
Use gnome-text-editor to replace gedit in the introduction of the document

### DIFF
--- a/WSL/tutorials/gui-apps.md
+++ b/WSL/tutorials/gui-apps.md
@@ -82,15 +82,15 @@ You can run the following commands from your Linux terminal to download and inst
 sudo apt update
 ```
 
-### Install Gedit
+### Install Gnome Text Editor
 
-Gedit is the default text editor of the GNOME desktop environment.
+Gnome Text Editor is the default text editor of the GNOME desktop environment.
 
 ```bash
-sudo apt install gedit -y
+sudo apt install gnome-text-editor -y
 ```
 
-To launch your bashrc file in the editor, enter: `gedit ~/.bashrc`
+To launch your bashrc file in the editor, enter: `gnome-text-editor ~/.bashrc`
 
 ### Install GIMP
 


### PR DESCRIPTION
- Fixes https://github.com/MicrosoftDocs/WSL/issues/1681.
- Use gnome-text-editor to replace gedit in the introduction of the document.