### PR TITLE
Updated guide to fix an issue because of a wrong command

### DIFF
--- a/WSL/tutorials/wsl-containers.md
+++ b/WSL/tutorials/wsl-containers.md
@@ -2,7 +2,7 @@
 title: Get started with Docker containers on WSL
 description: Learn how to set up Docker containers on the Windows Subsystem for Linux.
 keywords: wsl, windows, windowssubsystem, windows 10, docker, containers
-ms.date: 09/27/2021
+ms.date: 01/04/2024
 ms.topic: article
 ---
 
@@ -111,7 +111,7 @@ Let's use Docker to create a development container for an existing app project.
 
     ![VS Code WSL Remote indicator](../media/vscode-remote-indicator.png)
 
-4. From the VS Code command pallette (Ctrl + Shift + P), enter: **Dev Containers: Reopen in Container** as we are using a folder already opened using the WSL extension. Alternativly use **Dev Containers: Open Folder in Container...** to choose a WSL folder using the local \\wsl$ share (from the Windows side) (see [here](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container) for more details). If these commands don't display as you begin to type, check to ensure that you've installed the Dev Containers extension linked above. 
+4. From the VS Code command pallette (Ctrl + Shift + P), enter: **Dev Containers: Reopen in Container** as we are using a folder already opened using the WSL extension. Alternativly use **Dev Containers: Open Folder in Container...** to choose a WSL folder using the local `\\wsl$` share (from the Windows side). See the Visual Studio Code [Quick start: Open an existing folder in a container](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container) for more details. If these commands don't display as you begin to type, check to ensure that you've installed the Dev Containers extension linked above. 
 
     ![VS Code Dev Containers command](../media/docker-extension.png)
 

--- a/WSL/tutorials/wsl-containers.md
+++ b/WSL/tutorials/wsl-containers.md
@@ -111,7 +111,7 @@ Let's use Docker to create a development container for an existing app project.
 
     ![VS Code WSL Remote indicator](../media/vscode-remote-indicator.png)
 
-4. From the VS Code command pallette (Ctrl + Shift + P), enter: **Dev Containers: Open Folder in Container...** If this command doesn't display as you begin to type it, check to ensure that you've installed the Dev Containers extension linked above.
+4. From the VS Code command pallette (Ctrl + Shift + P), enter: **Dev Containers: Reopen in Container** as we are using a folder already opened using the WSL extension. Alternativly use **Dev Containers: Open Folder in Container...** to choose a WSL folder using the local \\wsl$ share (from the Windows side) (see [here](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container) for more details). If these commands don't display as you begin to type, check to ensure that you've installed the Dev Containers extension linked above. 
 
     ![VS Code Dev Containers command](../media/docker-extension.png)
 


### PR DESCRIPTION
Running Dev Containers: **Open Folder in Container...** when using this guide is not / no longer correct, as most readers will already have opened the folder while connected to WSL based on the steps provided above. We need to use **Dev Containers: Reopen in Container** or it will fail to create the .devcontainer folder and devcontainer.json and give a (unfortunately not very clear) error message.


See also: https://code.visualstudio.com/docs/devcontainers/containers#_open-a-wsl-2-folder-in-a-container-on-windows
   
- Use the Dev Containers: Reopen in Container command from a folder already opened using the WSL extension.
- Select Dev Containers: Open Folder in Container... from the Command Palette (F1) and choose a WSL folder using the local \\wsl$ share (from the Windows side).