### PR TITLE
fix ambiguous wording for required win version

### DIFF
--- a/WSL/wsl-config.md
+++ b/WSL/wsl-config.md
@@ -237,7 +237,7 @@ Entries with the `size` value must be a size followed by a unit, for example, `8
 
 Entries with an * after the value type are only available on Windows 11.
 
-Entries with an ** after the value type require [Windows version 22H2](https://blogs.windows.com/windows-insider/2023/09/14/releasing-windows-11-build-22621-2359-to-the-release-preview-channel/) or higher.
+Entries with an ** after the value type require [Windows 11 version 22H2](https://blogs.windows.com/windows-insider/2023/09/14/releasing-windows-11-build-22621-2359-to-the-release-preview-channel/) or higher.
 
 ### Experimental settings
 


### PR DESCRIPTION
Previously this part of the docs stated that Windows version 22H2 was required, but as I learned that is actually wrong:

https://github.com/microsoft/WSL/issues/10853

it is specifically Windows *11* version 22H2 that is required. Windows *10* version 22H2 does *not* work unfortunately.