### PR TITLE
Import export command clarification

### DIFF
--- a/WSL/basic-commands.md
+++ b/WSL/basic-commands.md
@@ -177,7 +177,7 @@ To terminate the specified distribution, or stop it from running, replace `<Dist
 wsl --export <Distribution Name> <FileName>
 ```
 
-Exports the specified tar file as a new distribution. The filename can be - for standard input. Options include:
+Exports a snapshot of the specified distribution as a new distribution file. Defaults to tar format. The filename can be `-` for standard input. Options include:
 
 - `--vhd`: Specifies the export distribution should be a .vhdx file instead of a tar file (this is only supported using WSL 2)
 
@@ -187,7 +187,7 @@ Exports the specified tar file as a new distribution. The filename can be - for 
 wsl --import <Distribution Name> <InstallLocation> <FileName>
 ```
 
-Imports the specified tar file as a new distribution. The filename can be - for standard input. Options include:
+Imports the specified tar file as a new distribution. The filename can be `-` for standard input. Options include:
 
 - `--vhd`: Specifies the import distribution should be a .vhdx file instead of a tar file (this is only supported using WSL 2)
 - `--version <1/2>`: Specifies whether to import the distribution as a WSL 1 or WSL 2 distribution

--- a/WSL/basic-commands.md
+++ b/WSL/basic-commands.md
@@ -171,20 +171,26 @@ To terminate the specified distribution, or stop it from running, replace `<Dist
 - `wsl hostname -i` for the IP address of your Linux distribution installed via WSL 2 (the WSL 2 VM address)
 - `cat /etc/resolv.conf` for the IP address of the Windows machine as seen from WSL 2 (the WSL 2 VM)
 
-## Import and export a distribution
+## Export a distribution
 
 ```powershell
 wsl --export <Distribution Name> <FileName>
 ```
 
+Exports the specified tar file as a new distribution. The filename can be - for standard input. Options include:
+
+- `--vhd`: Specifies the export distribution should be a .vhdx file instead of a tar file (this is only supported using WSL 2)
+
+## Import a distribution
+
 ```powershell
 wsl --import <Distribution Name> <InstallLocation> <FileName>
 ```
 
-Imports and exports the specified tar file as a new distribution. The filename can be - for standard input. Options include:
+Imports the specified tar file as a new distribution. The filename can be - for standard input. Options include:
 
-- `--vhd`: Specifies the import/export distribution should be a .vhdx file instead of a tar file (this is only supported using WSL 2)
-- `--version`: For import only, specifies whether to import the distribution as a WSL 1 or WSL 2 distribution
+- `--vhd`: Specifies the import distribution should be a .vhdx file instead of a tar file (this is only supported using WSL 2)
+- `--version <1/2>`: Specifies whether to import the distribution as a WSL 1 or WSL 2 distribution
 
 ## Import a distribution in place
 

--- a/WSL/faq.yml
+++ b/WSL/faq.yml
@@ -160,7 +160,7 @@ sections:
       - question: |
          How can I back up my WSL distributions?
         answer: |
-          The best way to backup or move your distributions is via the [export/import commands](./basic-commands.md#import-and-export-a-distribution) available in Windows Version 1809 and later. You can export your entire distribution to a tarball using the `wsl --export` command. You can then import this distribution back into WSL using the `wsl --import` command, which can name a new drive location for the import, allowing you to backup and save states of (or move) your WSL distributions. To learn more about moving your WSL distributions, see [How can I transfer my WSL files from one machine to another?](#how-can-i-transfer-my-wsl-files-from-one-machine-to-another-). 
+          The best way to backup or move your distributions is via the [export](./basic-commands.md#export-a-distribution)/[import](./basic-commands.md#import-a-distribution) commands available in Windows Version 1809 and later. You can export your entire distribution to a tarball using the `wsl --export` command. You can then import this distribution back into WSL using the `wsl --import` command, which can name a new drive location for the import, allowing you to backup and save states of (or move) your WSL distributions. To learn more about moving your WSL distributions, see [How can I transfer my WSL files from one machine to another?](#how-can-i-transfer-my-wsl-files-from-one-machine-to-another-). 
           
           Traditional backup services that backup files in your AppData folders (like Windows Backup) will not corrupt your Linux files.
 
@@ -186,7 +186,7 @@ sections:
         answer: |
          There are a few ways you can accomplish this task: 
           
-          * The easiest way is to use the `wsl --export --vhd` command to export your WSL distribution to a VHD file. You can then copy this file to another machine, and import it using `wsl --import --vhd`. See the [Import and Export distributions in the WSL basic commands](./basic-commands.md#import-and-export-a-distribution) doc for more information.
+          * The easiest way is to use the `wsl --export --vhd` command to export your WSL distribution to a VHD file. You can then copy this file to another machine, and import it using `wsl --import --vhd`. See the [import](./basic-commands.md#import-a-distribution) and [export](./basic-commands.md#export-a-distribution) commands in [the WSL basic commands](./basic-commands.md) doc for more information.
           * The implementation above requires a lot of disk space. If you don't have a lot of disk space you can use Linux techniques to move your files over:
              * Use `tar -czf <tarballName> <directory>` to create a tarball of your files. You can then copy these specific files over to your new machine and run `tar -xzf <tarballName>` to extract them.
              * You can also export a list of installed packages via `apt` with a command like so: `dpkg --get-selections | grep -v deinstall | awk '{print $1}' > package_list.txt` and then reinstall those same packages on another machine with a command like `sudo apt install -y $(cat package_list.txt)` after transferring the file over.


### PR DESCRIPTION
- My original intent was to clarify that the export command exports a **snapshot** of the specified distribution. The way it is currently written doesn't say otherwise, but it could be interpreted to mean it exports a clean install without the user's modifications. 

    - In other words, it could be saying `wsl --export Ubuntu ubuntu.tar` outputs the equivalent of downloading the official "ubuntu.tar" from the internet. 
- Splitting these two was not part of my original goal, merely a step along the way to achieve it.