### PR TITLE
Update troubleshooting.md when Network Manager is running

### DIFF
--- a/WSL/troubleshooting.md
+++ b/WSL/troubleshooting.md
@@ -320,6 +320,15 @@ WSL will automatically configure certain Linux networking settings when using mi
 
 There is a known issue in which Docker Desktop containers with published ports (docker run –publish/-p) will fail to be created. The WSL team is working with the Docker Desktop team to address this issue. To work around the issue, use the host’s networking namespace in the Docker container. Set the network type via the "--network host" option used in the "docker run" command. An alternative workaround is to list the published port number in the `ignoredPorts` setting of the [experimental section in the WSL Configuration file](/windows/wsl/wsl-config#experimental-settings). 
 
+### Docker container issues when its Network Manager is running
+
+There is a known issue with Docker containers which have the Network Manager service running. Sympoms include failures when trying to make loopback connections to the host.
+It's recommended to stop the Network Manager service for WSL networking to be configured properly:
+
+```Bash
+sudo systemctl disable network-manager.service
+```
+
 ### DNS suffixes in WSL
 
 Depending on the configurations in the .wslconfig file, WSL will have the following behavior wrt DNS suffixes:

--- a/WSL/troubleshooting.md
+++ b/WSL/troubleshooting.md
@@ -322,8 +322,8 @@ There is a known issue in which Docker Desktop containers with published ports (
 
 ### Docker container issues when its Network Manager is running
 
-There is a known issue with Docker containers which have the Network Manager service running. Sympoms include failures when trying to make loopback connections to the host.
-It's recommended to stop the Network Manager service for WSL networking to be configured properly:
+There is a known issue with Docker containers which have the Network Manager service running. Symptoms include failures when trying to make loopback connections to the host.
+It is recommended to stop the Network Manager service for WSL networking to be configured properly.
 
 ```Bash
 sudo systemctl disable network-manager.service


### PR DESCRIPTION
There are known incompatibilities when the Network Manager service is running within the Linux container. This documents this issue and how to stop that service.