### PR TITLE
Fix umask default for DrvFs automount

### DIFF
--- a/WSL/wsl-config.md
+++ b/WSL/wsl-config.md
@@ -82,7 +82,7 @@ Setting different mount options for Windows drives (DrvFs) can control how file 
 |:----|:----|:----|
 | `uid` | The User ID used for the owner of all files | The default User ID of your WSL distro (on first installation this defaults to 1000)
 | `gid` | The Group ID used for the owner of all files | The default group ID of your WSL distro (on first installation this defaults to 1000)
-| `umask` | An octal mask of permissions to exclude for all files and directories | `022`
+| `umask` | An octal mask of permissions to exclude for all files and directories | `000`
 | `fmask` | An octal mask of permissions to exclude for all files | `000`
 | `dmask` | An octal mask of permissions to exclude for all directories | `000`
 | `metadata` | Whether metadata is added to Windows files to support Linux system permissions | `disabled`
@@ -90,7 +90,7 @@ Setting different mount options for Windows drives (DrvFs) can control how file 
 
 By default, WSL sets the uid and gid to the value of the default user. For example, in Ubuntu, the default user is uid=1000, gid=1000. If this value is used to specify a different gid or uid option, the default user value will be overwritten. Otherwise, the default value will always be appended.
 
-User file-creation mode mask (umask) sets permission for newly created files. The default is 022, only you can write data but anyone can read data. Values can be changed to reflect different permission settings. For example, `umask=077` changes permission to be completely private, no other user can read or write data. To further specify permission, fmask (files) and dmask (directories) can also be used.
+User file-creation mode mask (umask) sets permission for newly created files. The default is `000`, meaning anyone can read, write, or execute files. Values can be changed to reflect different permission settings. For example, `umask=077` changes permission to be completely private, no other user can read or write data. To further specify permission, fmask (files) and dmask (directories) can also be used.
 
 > [!NOTE]
 > The permission masks are put through a logical OR operation before being applied to files or directories.

--- a/WSL/wsl-config.md
+++ b/WSL/wsl-config.md
@@ -90,7 +90,7 @@ Setting different mount options for Windows drives (DrvFs) can control how file 
 
 By default, WSL sets the uid and gid to the value of the default user. For example, in Ubuntu, the default user is uid=1000, gid=1000. If this value is used to specify a different gid or uid option, the default user value will be overwritten. Otherwise, the default value will always be appended.
 
-User file-creation mode mask (umask) sets permission for newly created files. The default is `000`, meaning anyone can read, write, or execute files. Values can be changed to reflect different permission settings. For example, `umask=077` changes permission to be completely private, no other user can read or write data. To further specify permission, fmask (files) and dmask (directories) can also be used.
+The above umask, fmask, etc. options will only apply when the Windows drive is mounted with metadata. By default metadata is not enabled. You can [find more info about this here](./file-permissions). User file-creation mode mask (umask) sets permission for newly created files. The default is `000`, meaning anyone can read, write, or execute files. Values can be changed to reflect different permission settings. For example, `umask=077` changes permission to be completely private, no other user can read or write data. To further specify permission, fmask (files) and dmask (directories) can also be used.
 
 > [!NOTE]
 > The permission masks are put through a logical OR operation before being applied to files or directories.

--- a/WSL/wsl-config.md
+++ b/WSL/wsl-config.md
@@ -82,7 +82,7 @@ Setting different mount options for Windows drives (DrvFs) can control how file 
 |:----|:----|:----|
 | `uid` | The User ID used for the owner of all files | The default User ID of your WSL distro (on first installation this defaults to 1000)
 | `gid` | The Group ID used for the owner of all files | The default group ID of your WSL distro (on first installation this defaults to 1000)
-| `umask` | An octal mask of permissions to exclude for all files and directories | `000`
+| `umask` | An octal mask of permissions to exclude for all files and directories | `000` or `022` when metadata is enabled
 | `fmask` | An octal mask of permissions to exclude for all files | `000`
 | `dmask` | An octal mask of permissions to exclude for all directories | `000`
 | `metadata` | Whether metadata is added to Windows files to support Linux system permissions | `disabled`

--- a/WSL/wsl-config.md
+++ b/WSL/wsl-config.md
@@ -90,7 +90,7 @@ Setting different mount options for Windows drives (DrvFs) can control how file 
 
 By default, WSL sets the uid and gid to the value of the default user. For example, in Ubuntu, the default user is uid=1000, gid=1000. If this value is used to specify a different gid or uid option, the default user value will be overwritten. Otherwise, the default value will always be appended.
 
-The above umask, fmask, etc. options will only apply when the Windows drive is mounted with metadata. By default metadata is not enabled. You can [find more info about this here](./file-permissions). User file-creation mode mask (umask) sets permission for newly created files. The default is `000`, meaning anyone can read, write, or execute files. Values can be changed to reflect different permission settings. For example, `umask=077` changes permission to be completely private, no other user can read or write data. To further specify permission, fmask (files) and dmask (directories) can also be used.
+The above umask, fmask, etc. options will only apply when the Windows drive is mounted with metadata. By default metadata is not enabled. You can [find more info about this here](./file-permissions). 
 
 > [!NOTE]
 > The permission masks are put through a logical OR operation before being applied to files or directories.

--- a/WSL/wsl-config.md
+++ b/WSL/wsl-config.md
@@ -82,7 +82,7 @@ Setting different mount options for Windows drives (DrvFs) can control how file 
 |:----|:----|:----|
 | `uid` | The User ID used for the owner of all files | The default User ID of your WSL distro (on first installation this defaults to 1000)
 | `gid` | The Group ID used for the owner of all files | The default group ID of your WSL distro (on first installation this defaults to 1000)
-| `umask` | An octal mask of permissions to exclude for all files and directories | `000` or `022` when metadata is enabled
+| `umask` | An octal mask of permissions to exclude for all files and directories | `022`
 | `fmask` | An octal mask of permissions to exclude for all files | `000`
 | `dmask` | An octal mask of permissions to exclude for all directories | `000`
 | `metadata` | Whether metadata is added to Windows files to support Linux system permissions | `disabled`


### PR DESCRIPTION
Fixes #1628 and fixes #1767 so that the docs are consistent with the real behavior of WSL2. From testing, WSL has a default umask of 000, not 022.

## Testing done

1. Create a new file: `touch /mnt/c/temp/testfile`.
2. Edit /etc/wsl.conf so that the `[automount]` section does not contain the key-value pair `options = ...` and save the file. This ensures the default umask is applied.
3. Run `wsl.exe --shutdown`.
4. Wait 8 seconds.
5. Open WSL and check the mode of the test file:
```sh
$ ls -lh /mnt/c/temp/testfile
-rwxrwxrwx 1 myusername myusername 0 Dec  0 09:33 /mnt/c/temp/testfile
```
Note that all the permission bits are set, meaning the default umask is `000`: anyone can read, write, or execute files.