### PR TITLE
Put the whole command in a block

### DIFF
--- a/WSL/networking.md
+++ b/WSL/networking.md
@@ -68,7 +68,7 @@ If you want to access a networking app running on Windows (for example an app ru
 ```bash
 ip route show | grep -i default | awk '{ print $3}'`
 ```
-3. Connect to any Windows server using the copied IP address.
+2. Connect to any Windows server using the copied IP address.
 
 The picture below shows an example of this by connecting to a Node.js server running in Windows via curl.
 

--- a/WSL/networking.md
+++ b/WSL/networking.md
@@ -64,8 +64,11 @@ If you are building a networking app (for example an app running on a NodeJS or 
 
 If you want to access a networking app running on Windows (for example an app running on a NodeJS or SQL server) from your Linux distribution (ie Ubuntu), then you need to use the IP address of your host machine. While this is not a common scenario, you can follow these steps to make it work.
 
-1. Obtain the IP address of your host machine by running this command from your Linux distribution: `ip route show | grep -i default | awk '{ print $3}'`
-2. Connect to any Windows server using the copied IP address.
+1. Obtain the IP address of your host machine by running this command from your Linux distribution: 
+```bash
+ip route show | grep -i default | awk '{ print $3}'`
+```
+3. Connect to any Windows server using the copied IP address.
 
 The picture below shows an example of this by connecting to a Node.js server running in Windows via curl.
 


### PR DESCRIPTION
This pull request includes a small change to the `WSL/networking.md` file. The change improves the readability of the instructions for getting the IP address of the host machine by formatting the command as a code block.

* [`WSL/networking.md`](diffhunk://#diff-eda329c65c5e7b31eda1abcb1a3a6becf25128df66aefc8c7e161e8f19acd29fL67-R71): Formatted the command to get the IP address of the host machine as a code block for better readability.

Without this change, the command gets inline and breaks at the beginning, confusing the reader, making them think the command begins by route instead of ip.
