### PR TITLE
Add documentation for shortcut.enabled and windowsterminal.enabled

### DIFF
--- a/WSL/build-custom-distro.md
+++ b/WSL/build-custom-distro.md
@@ -65,9 +65,9 @@ WSL distribution file configuration options:
 | `oobe.defaultUid` | integer | `<none>` | The default UID that the distribution starts with. This is useful when the `oobe.command` script creates a new user. |
 | `oobe.defaultName`| string | `<none>` | The default name that the distribution is registered under. This default name can be replaced with the command: `wsl.exe --install <distro> --name <name>` |
 | `shortcut.icon` | string | The default WSL icon | The icon in the start menu shortcut for the distribution. Must be in `.ico` format with a maximum size of `10MB` |
-| `shortcut.enabled` | boolean | true | Create a start menu shortcut for the distribution | Wether a start menu shortcut should be created when the distribution is installed. |
-| `windowsterminal.profileTemplate` | string | Path to a terminal template file | The JSON template to generate a Windows Terminal profile for this distribution. |
-| `windowsterminal.enabled` | boolean | true | Generate a terminal profile for the distribution | Wether a terminal profile should be created when the distribution is installed. If `profileTemplate` is not set, a default profile will be generated. | 
+| `shortcut.enabled` | boolean | true | Whether a start menu shortcut should be created when the distribution is installed. |
+| `windowsterminal.profileTemplate` | string | `<none>` | The JSON template to generate a Windows Terminal profile for this distribution. |
+| `windowsterminal.enabled` | boolean | true | Whether a terminal profile should be created when the distribution is installed. If `profileTemplate` is not set, a default profile will be generated. | 
 
 You need to create an out of box experience (OOBE) first run experience for the distribution. Below is a sample bash script that you can use. This script assumes that `oobe.defaultUid` is set to `1000`: 
 

--- a/WSL/build-custom-distro.md
+++ b/WSL/build-custom-distro.md
@@ -49,9 +49,11 @@ defaultUid = 1000
 defaultName = my-distro
 
 [shortcut]
+enabled = true
 icon = /usr/lib/wsl/my-icon.ico
 
 [windowsterminal]
+enabled = true
 ProfileTemplate = /usr/lib/wsl/terminal-profile.json
 ```
 
@@ -63,7 +65,9 @@ WSL distribution file configuration options:
 | `oobe.defaultUid` | integer | `<none>` | The default UID that the distribution starts with. This is useful when the `oobe.command` script creates a new user. |
 | `oobe.defaultName`| string | `<none>` | The default name that the distribution is registered under. This default name can be replaced with the command: `wsl.exe --install <distro> --name <name>` |
 | `shortcut.icon` | string | The default WSL icon | The icon in the start menu shortcut for the distribution. Must be in `.ico` format with a maximum size of `10MB` |
-| `windowsterminal.profileTemplate` | string | Path to a terminal template file | The JSON template to generate a Windows Terminal profile for this distribution. | 
+| `shortcut.enabled` | boolean | true | Create a start menu shortcut for the distribution | Wether a start menu shortcut should be created when the distribution is installed. |
+| `windowsterminal.profileTemplate` | string | Path to a terminal template file | The JSON template to generate a Windows Terminal profile for this distribution. |
+| `windowsterminal.enabled` | boolean | true | Generate a terminal profile for the distribution | Wether a terminal profile should be created when the distribution is installed. If `profileTemplate` is not set, a default profile will be generated. | 
 
 You need to create an out of box experience (OOBE) first run experience for the distribution. Below is a sample bash script that you can use. This script assumes that `oobe.defaultUid` is set to `1000`: 
 


### PR DESCRIPTION
This change adds documentation for the new `shortcut.enabled` and `windowsterminal.enabled`  configuration values in `wsl-distribution.conf`