### PR TITLE
Fix incorrect "hostname -i" command in networking.md

### DIFF
--- a/WSL/networking.md
+++ b/WSL/networking.md
@@ -19,12 +19,12 @@ There are two scenarios to consider when identifying the IP address used for a L
 The Windows host can use command:
 
 ```
-wsl -d <DistributionName> hostname -i
+wsl -d <DistributionName> hostname -I
 ```
 
-If querying the default distribution, this part of the command designating the distribution can be omitted: `-d <DistributionName>`. Be sure to use a lower-case `-i` flag.
+If querying the default distribution, this part of the command designating the distribution can be omitted: `-d <DistributionName>`. Be sure to use a capital `-I` flag and not a lower-case `-i`.
 
-Under the hood, host command `wsl.exe` launches the target instance and executes Linux command `hostname --ip-addresses`. This command then prints the IP address of the WSL instance to `STDOUT`. The `STDOUT` text content is then relayed back to wsl.exe. Finally, wsl.exe displays that output to the command line. 
+Under the hood, host command `wsl.exe` launches the target instance and executes Linux command `hostname -I` (short notation for `--all-ip-addresses`). This command then prints the IP address of the WSL instance to `STDOUT`. The `STDOUT` text content is then relayed back to wsl.exe. Finally, wsl.exe displays that output to the command line. 
 
 A typical output might be:
 


### PR DESCRIPTION
The lower case "-i" will return a "127.0.1.1" which is a loop back address. The address cannot be accessed from Windows side. The upper-case "-I" instead will return the outside address of the WSL instance seen by Windows.

Thus "-I" should be used instead of "-i" to get the host IP seen from WSL. There's already a note saying about this below the changed part.

This commit mainly reverts the change of PR #2033.