### PR TITLE
Update resizing docs for new manage command

### DIFF
--- a/WSL/disk-space.md
+++ b/WSL/disk-space.md
@@ -45,6 +45,28 @@ If you see that you are near to reaching the available amount of disk space allo
 
 ## How to expand the size of your WSL 2 Virtual Hard Disk
 
+### Expansion using `wsl --manage`
+
+These instructions only apply to WSL releases 2.5 and higher.
+
+To expand the VHD size for a Linux distribution beyond the **default 1TB maximum** amount of allocated disk space, WSL provides the `wsl --manage` command with resize functionality. To resize your disk, follow the steps below.
+
+1. Terminate all WSL instances using the command `wsl.exe --shutdown`
+
+2. Run `wsl --manage <distribution name> --resize <memory string>`. Supported memory strings are of the form `<Memory Value>B/M/MB/G/GB/T/TB`. Decimal values are currently unsupported (e.g. `2.5TB`).
+
+The output should look similar to the following:
+```bash
+e2fsck 1.46.5 (30-Dec-2021)
+Pass 1: Checking inodes, blocks, and sizes
+resize2fs 1.46.5 (30-Dec-2021)
+The operation completed successfully.
+```
+
+The virtual drive (ext4.vhdx) for this Linux distribution has now successfully been expanded to the new size.
+
+### Manual expansion
+
 To expand the VHD size for a Linux distribution beyond the **default 1TB maximum** amount of allocated disk space, follow the steps below. *(For earlier WSL releases that have not yet been updated, this max default may be set to 512GB or 256GB).*
 
 1. Terminate all WSL instances using the command: `wsl.exe --shutdown`
@@ -112,7 +134,7 @@ old_desc_blocks = 32, new_desc_blocks = 38
 The filesystem on /dev/sdb is now 78643200 (4k) blocks long.
 ```
 
-The virtual drive (ext4.vhdx) for this Linux distribution has now successfully been expanded to the new size.  
+The virtual drive (ext4.vhdx) for this Linux distribution has now successfully been expanded to the new size.
 
 > [!IMPORTANT]
 > We recommend that you do not modify, move, or access the WSL related files located inside of your `AppData` folder using Windows tools or editors. Doing so could cause your Linux distribution to become corrupted. If you would like to access your Linux files from Windows, that is possible via the path `\\wsl$\<distribution-name>\`. Open your WSL distribution and enter `explorer.exe .` to view that folder. To learn more, see the blog post: [Accessing Linux files from Windows](https://devblogs.microsoft.com/commandline/whats-new-for-wsl-in-windows-10-version-1903/#accessing-linux-files-from-windows).


### PR DESCRIPTION
This adds a section that utilizes the `wsl --manage` command to resize a hard drive instead of the currently present manual steps. 