### PR TITLE
Use consistent table formatting in wsl-config

### DIFF
--- a/WSL/wsl-config.md
+++ b/WSL/wsl-config.md
@@ -62,12 +62,12 @@ You will then need to close your WSL distribution using `wsl.exe --shutdown` fro
 
 wsl.conf section label: `[automount]`
 
-| key | value | default | notes |
+| Key | Value | Default | Notes |
 |:-----------|:---------|:--------|:------|
-| `enabled` | boolean | `true` | `true` causes fixed drives (i.e `C:/` or `D:/`) to be automatically mounted with DrvFs under `/mnt`.  `false` means drives won't be mounted automatically, but you could still mount them manually or via `fstab`.                                                                                                             |
-| `mountFsTab` | boolean | `true` | `true` sets `/etc/fstab` to be processed on WSL start. /etc/fstab is a file where you can declare other filesystems, like an SMB share. Thus, you can mount these filesystems automatically in WSL on start up.                                                                                                                |
-| `root`| string | `/mnt/` | Sets the directory where fixed drives will be automatically mounted. By default this is set to `/mnt/`, so your Windows file system C-drive is mounted to `/mnt/c/`. If you change `/mnt/` to `/windir/`, you should expect to see your fixed C-drive mounted to `/windir/c`.|
-| `options` | comma-separated list of values, such as uid, gid, etc, see automount options below | empty string | The automount option values are listed below and are appended to the default DrvFs mount options string. **Only DrvFs-specific options can be specified.**|
+| `enabled` | boolean | `true` | `true` causes fixed drives (i.e `C:/` or `D:/`) to be automatically mounted with DrvFs under `/mnt`.  `false` means drives won't be mounted automatically, but you could still mount them manually or via `fstab`. |
+| `mountFsTab` | boolean | `true` | `true` sets `/etc/fstab` to be processed on WSL start. /etc/fstab is a file where you can declare other filesystems, like an SMB share. Thus, you can mount these filesystems automatically in WSL on start up. |
+| `root` | string | `/mnt/` | Sets the directory where fixed drives will be automatically mounted. By default this is set to `/mnt/`, so your Windows file system C-drive is mounted to `/mnt/c/`. If you change `/mnt/` to `/windir/`, you should expect to see your fixed C-drive mounted to `/windir/c`. |
+| `options` | comma-separated list of values, such as uid, gid, etc, see automount options below | `""` | The automount option values are listed below and are appended to the default DrvFs mount options string. **Only DrvFs-specific options can be specified.** |
 
 The automount options are applied as the mount options for all automatically mounted drives. To change the options for a specific drive only, use the `/etc/fstab` file instead. Options that the mount binary would normally parse into a flag are not supported. If you want to explicitly specify those options, you must include every drive for which you want to do so in `/etc/fstab`.
 
@@ -77,13 +77,13 @@ Setting different mount options for Windows drives (DrvFs) can control how file 
 
 | Key | Description | Default |
 |:----|:----|:----|
-| `uid` | The User ID used for the owner of all files | The default User ID of your WSL distro (on first installation this defaults to 1000)
-| `gid` | The Group ID used for the owner of all files | The default group ID of your WSL distro (on first installation this defaults to 1000)
-| `umask` | An octal mask of permissions to exclude for all files and directories | `022`
-| `fmask` | An octal mask of permissions to exclude for all files | `000`
-| `dmask` | An octal mask of permissions to exclude for all directories | `000`
-| `metadata` | Whether metadata is added to Windows files to support Linux system permissions | `disabled`
-| `case` | Determines directories treated as case sensitive and whether new directories created with WSL will have the flag set. See [case sensitivity](./case-sensitivity.md) for a detailed explanation of the options. Options include `off`, `dir`, or `force`. | `off`
+| `uid` | The User ID used for the owner of all files | The default User ID of your WSL distro (on first installation this defaults to 1000) |
+| `gid` | The Group ID used for the owner of all files | The default group ID of your WSL distro (on first installation this defaults to 1000) |
+| `umask` | An octal mask of permissions to exclude for all files and directories | `022` |
+| `fmask` | An octal mask of permissions to exclude for all files | `000` |
+| `dmask` | An octal mask of permissions to exclude for all directories | `000` |
+| `metadata` | Whether metadata is added to Windows files to support Linux system permissions | `disabled` |
+| `case` | Determines directories treated as case sensitive and whether new directories created with WSL will have the flag set. See [case sensitivity](./case-sensitivity.md) for a detailed explanation of the options. Options include `off`, `dir`, or `force`. | `off` |
 
 By default, WSL sets the uid and gid to the value of the default user. For example, in Ubuntu, the default user is uid=1000, gid=1000. If this value is used to specify a different gid or uid option, the default user value will be overwritten. Otherwise, the default value will always be appended.
 
@@ -100,7 +100,7 @@ DrvFs is a filesystem plugin to WSL that was designed to support interop between
 
 wsl.conf section label: `[network]`
 
-| key | value | default | notes|
+| Key | Value | Default | Notes |
 |:----|:----|:----|:----|
 | `generateHosts` | boolean | `true` | `true` sets WSL to generate `/etc/hosts`. The `hosts` file contains a static map of hostnames corresponding IP address. |
 | `generateResolvConf` | boolean | `true` | `true` sets WSL to generate `/etc/resolv.conf`. The `resolv.conf` contains a DNS list that are capable of resolving a given hostname to its IP address. |
@@ -112,7 +112,7 @@ wsl.conf section label: `[interop]`
 
 These options are available in Insider Build 17713 and later.
 
-| key | value | default | notes|
+| Key | Value | Default | Notes |
 |:----|:----|:----|:----|
 | `enabled` | boolean | `true` | Setting this key will determine whether WSL will support launching Windows processes. |
 | `appendWindowsPath` | boolean | `true` | Setting this key will determine whether WSL will add Windows path elements to the $PATH environment variable. |
@@ -123,7 +123,7 @@ wsl.conf section label: `[user]`
 
 These options are available in Build 18980 and later.
 
-| key | value | default | notes|
+| Key | Value | Default | Notes |
 |:----|:----|:----|:----|
 | `default` | string | The initial username created on first run | Setting this key specifies which user to run as when first starting a WSL session. |
 
@@ -133,9 +133,9 @@ The Boot setting is only available on Windows 11 and Server 2022.
 
 wsl.conf section label: `[boot]`
 
-| key | value | default | notes|
+| Key | Value | Default | Notes |
 |:----|:----|:----|:----|
-| `command` | string | "" | A string of the command that you would like to run when the WSL instance starts. This command is run as the root user. e.g: `service docker start`.|
+| `command` | string | `""` | A string of the command that you would like to run when the WSL instance starts. This command is run as the root user. e.g: `service docker start`. |
 
 ### Example wsl.conf file
 
@@ -203,27 +203,27 @@ This file can contain the following options that affect the VM that powers any W
 
 .wslconfig section label: `[wsl2]`
 
-| key | value | default | notes|
+| Key | Value | Default | Notes |
 |:----|:----|:----|:----|
 | `kernel` | path | The Microsoft built kernel provided inbox | An absolute Windows path to a custom Linux kernel. |
 | `memory` | size | 50% of total memory on Windows | How much memory to assign to the WSL 2 VM. |
 | `processors` | number | The same number of logical processors on Windows | How many logical processors to assign to the WSL 2 VM. |
 | `localhostForwarding` | boolean | `true` | Boolean specifying if ports bound to wildcard or localhost in the WSL 2 VM should be connectable from the host via `localhost:port`. |
-| `kernelCommandLine` | string | Blank | Additional kernel command line arguments. |
-| `safeMode` | boolean | `false` | Run WSL in "Safe Mode" which disables many features and is intended to be used to recover distributions that are in bad states. Only available for Windows 11 and WSL version 0.66.2+.  |
-| `swap` | size | 25% of memory size on Windows rounded up to the nearest GB | How much swap space to add to the WSL 2 VM, 0 for no swap file. Swap storage is disk-based RAM used when memory demand exceeds limit on hardware device. |
+| `kernelCommandLine` | string | `""` | Additional kernel command line arguments. |
+| `safeMode`* | boolean | `false` | Run WSL in "Safe Mode" which disables many features and is intended to be used to recover distributions that are in bad states. Only available for Windows 11 and WSL version 0.66.2+. |
+| `swap` | size | 25% of memory size on Windows rounded up to the nearest GB | How much swap space to add to the WSL 2 VM, `0` for no swap file. Swap storage is disk-based RAM used when memory demand exceeds limit on hardware device. |
 | `swapFile` | path | `%USERPROFILE%\AppData\Local\Temp\swap.vhdx` | An absolute Windows path to the swap virtual hard disk. |
 | `pageReporting` | boolean | `true` | Default `true` setting enables Windows to reclaim unused memory allocated to WSL 2 virtual machine. |
-| `guiApplications` | boolean | `true` | Boolean to turn on or off support for GUI applications ([WSLg](https://github.com/microsoft/wslg)) in WSL.|
-| `debugConsole`* | boolean | `false` | Boolean to turn on an output console Window that shows the contents of `dmesg` upon start of a WSL 2 distro instance. Only available for Windows 11.|
-| `nestedVirtualization`* | boolean | `true` | Boolean to turn on or off nested virtualization, enabling other nested VMs to run inside WSL 2. Only available for Windows 11.|
-| `vmIdleTimeout`* | number | `60000` | The number of milliseconds that a VM is idle, before it is shut down. Only available for Windows 11.|
+| `guiApplications` | boolean | `true` | Boolean to turn on or off support for GUI applications ([WSLg](https://github.com/microsoft/wslg)) in WSL. |
+| `debugConsole`* | boolean | `false` | Boolean to turn on an output console Window that shows the contents of `dmesg` upon start of a WSL 2 distro instance. Only available for Windows 11. |
+| `nestedVirtualization`* | boolean | `true` | Boolean to turn on or off nested virtualization, enabling other nested VMs to run inside WSL 2. Only available for Windows 11. |
+| `vmIdleTimeout`* | number | `60000` | The number of milliseconds that a VM is idle, before it is shut down. Only available for Windows 11. |
 | `dnsProxy` | boolean | `true` | Only applicable to networkingMode = NAT. Boolean to inform WSL to configure the DNS Server in Linux to the NAT on the host. Setting to false will mirror DNS servers from Windows to Linux. |
 | `networkingMode`** | string | `NAT` | If the value is `mirrored` then this turns on mirrored networking mode. Default or unrecognized strings result in NAT networking. |
 | `firewall`** | boolean | `true` | Setting this to true allows the Windows Firewall rules, as well as rules specific to Hyper-V traffic, to filter WSL network traffic. |
 | `dnsTunneling`** | boolean | `true` | Changes how DNS requests are proxied from WSL to Windows |
 | `autoProxy`* | boolean | `true` | Enforces WSL to use Windows’ HTTP proxy information |
-| `defaultVhdSize` | size | `1099511627776` (1TB) | Set the Virtual Hard Disk (VHD) size that stores the Linux distribution (for example, Ubuntu) file system. Can be used to limit the maximum size that a distribution file system is allowed to take up. |
+| `defaultVhdSize` | size | `1TB` | Set the Virtual Hard Disk (VHD) size that stores the Linux distribution (for example, Ubuntu) file system. Can be used to limit the maximum size that a distribution file system is allowed to take up. |
 
 Entries with the `path` value must be Windows paths with escaped backslashes, e.g: `C:\\Temp\\myCustomKernel`
 
@@ -239,15 +239,15 @@ These settings are opt-in previews of experimental features that we aim to make 
 
 .wslconfig section label: `[experimental]`
 
-| Setting name | Value | Default | Notes |
+| Key | Value | Default | Notes |
 |:----|:----|:----|:----|
-|`autoMemoryReclaim`| string | `dropCache` | Automatically releases cached memory after detecting idle CPU usage. Set to `gradual` for slow release, and `dropCache` for instant release of cached memory. |
-|`sparseVhd`| bool | `false` | When set to true, any newly created VHD will be set to sparse automatically. |
-|`bestEffortDnsParsing`**| bool | `false` | Only applicable when `wsl2.dnsTunneling` is set to true. When set to true, Windows will extract the question from the DNS request and attempt to resolve it, ignoring the unknown records. |
-|`dnsTunnelingIpAddress`**| string | `10.255.255.254` | Only applicable when `wsl2.dnsTunneling` is set to true. Specifies the nameserver that will be configured in the Linux resolv.conf file when DNS tunneling is enabled. |
-|`initialAutoProxyTimeout`*| string | `1000` | Only applicable when `wsl2.autoProxy` is set to true. Configures how long (in milliseconds) WSL will wait for retrieving HTTP proxy information when starting a WSL container. If proxy settings are resolved after this time, the WSL instance must be restarted to use the retrieved proxy settings. |
-|`ignoredPorts`**| string | null | Only applicable when `wsl2.networkingMode` is set to `mirrored`. Specifies which ports Linux applications can bind to, even if that port is used in Windows. This enables applications to listen on a port for traffic purely within Linux, so those applications are not blocked even when that port is used for other purposes on Windows. For example, WSL will allow binding to port 53 in Linux for Docker Desktop, as it is listening only to requests from within the Linux container. Should be formatted in a comma separated list, e.g: `3000,9000,9090` |
-|`hostAddressLoopback`**| bool | `false` | Only applicable when `wsl2.networkingMode` is set to `mirrored`. When set to `True`, will allow the Container to connect to the Host, or the Host to connect to the Container, by an IP address that's assigned to the Host. The `127.0.0.1` loopback address can always be used,this option allows for all additionally assigned local IP addresses to be used as well. Only IPv4 addresses assigned to the host are supported. |
+| `autoMemoryReclaim` | string | `dropCache` | Automatically releases cached memory after detecting idle CPU usage. Set to `gradual` for slow release, and `dropCache` for instant release of cached memory. |
+| `sparseVhd` | boolean | `false` | When set to `true`, any newly created VHD will be set to sparse automatically. |
+| `bestEffortDnsParsing`** | boolean | `false` | Only applicable when `wsl2.dnsTunneling` is set to `true`. When set to `true`, Windows will extract the question from the DNS request and attempt to resolve it, ignoring the unknown records. |
+| `dnsTunnelingIpAddress`** | string | `10.255.255.254` | Only applicable when `wsl2.dnsTunneling` is set to `true`. Specifies the nameserver that will be configured in the Linux resolv.conf file when DNS tunneling is enabled. |
+| `initialAutoProxyTimeout`* | string | `1000` | Only applicable when `wsl2.autoProxy` is set to true. Configures how long (in milliseconds) WSL will wait for retrieving HTTP proxy information when starting a WSL container. If proxy settings are resolved after this time, the WSL instance must be restarted to use the retrieved proxy settings. |
+| `ignoredPorts`** | string | `""` | Only applicable when `wsl2.networkingMode` is set to `mirrored`. Specifies which ports Linux applications can bind to, even if that port is used in Windows. This enables applications to listen on a port for traffic purely within Linux, so those applications are not blocked even when that port is used for other purposes on Windows. For example, WSL will allow binding to port 53 in Linux for Docker Desktop, as it is listening only to requests from within the Linux container. Should be formatted in a comma separated list, e.g: `3000,9000,9090` |
+| `hostAddressLoopback`** | boolean | `false` | Only applicable when `wsl2.networkingMode` is set to `mirrored`. When set to `true`, will allow the Container to connect to the Host, or the Host to connect to the Container, by an IP address that's assigned to the Host. The `127.0.0.1` loopback address can always be used,this option allows for all additionally assigned local IP addresses to be used as well. Only IPv4 addresses assigned to the host are supported. |
 
 Entries with an * after the value type are only available on Windows 11.
 


### PR DESCRIPTION
Use consistent capitalization and spacing for tables, use `""` as the default for blank strings, use a proper `size` value as a default for `defaultVhdSize`, and add some missing code tags.