### PR TITLE
add kernelModules documentation

### DIFF
--- a/WSL/wsl-config.md
+++ b/WSL/wsl-config.md
@@ -206,6 +206,7 @@ This file can contain the following options that affect the VM that powers any W
 | key | value | default | notes|
 |:----|:----|:----|:----|
 | `kernel` | path | The Microsoft built kernel provided inbox | An absolute Windows path to a custom Linux kernel. |
+| `kernelModules` | path | An absolute Windows path to a custom Linux kernel modules VHD. |
 | `memory` | size | 50% of total memory on Windows | How much memory to assign to the WSL 2 VM. |
 | `processors` | number | The same number of logical processors on Windows | How many logical processors to assign to the WSL 2 VM. |
 | `localhostForwarding` | boolean | `true` | Boolean specifying if ports bound to wildcard or localhost in the WSL 2 VM should be connectable from the host via `localhost:port`. |
@@ -269,6 +270,9 @@ processors=2
 
 # Specify a custom Linux kernel to use with your installed distros. The default kernel used can be found at https://github.com/microsoft/WSL2-Linux-Kernel
 kernel=C:\\temp\\myCustomKernel
+
+# Specify the modules VHD for the custum Linux kernel to use with your installed distros.
+kernelModules=C:\\temp\\modules.vhdx
 
 # Sets additional kernel parameters, in this case enabling older Linux base images such as Centos 6
 kernelCommandLine = vsyscall=emulate


### PR DESCRIPTION
This pull request includes updates to the `WSL/wsl-config.md` file to support specifying custom Linux kernel modules for WSL 2. The key changes are:

* Added a new configuration option `kernelModules` to specify the path to a custom Linux kernel modules VHD in the configuration table.
* Added an example usage of the `kernelModules` option in the configuration file.