### PR TITLE
"Change directory to home" is not accurate

### DIFF
--- a/WSL/basic-commands.md
+++ b/WSL/basic-commands.md
@@ -75,7 +75,7 @@ wsl --set-default <Distribution Name>
 
 To set the default Linux distribution that WSL commands will use to run, replace `<Distribution Name>` with the name of your preferred Linux distribution.
 
-## Change directory to home
+## Start WSL in user's home
 
 ```powershell
 wsl ~


### PR DESCRIPTION
This pull request includes a small change to the `WSL/basic-commands.md` file. The change updates the section header to better reflect the command's functionality. 

* [`WSL/basic-commands.md`](diffhunk://#diff-b05a62aae85143e23a31dcfb224c091ec5749ab6b0a594fda9f4104f3f140041L78-R78): Changed the section header from "Change directory to home" to "Start WSL in user's home."