### PR TITLE
doc: incorrect link to usbipd-win GitHub repository

### DIFF
--- a/WSL/connect-usb.md
+++ b/WSL/connect-usb.md
@@ -87,6 +87,6 @@ Before attaching your USB device, ensure that a WSL command line is open.  This 
     usbipd detach --busid <busid>
     ```
 
-To learn more about how this works, see the [Windows Command Line Blog](https://devblogs.microsoft.com/commandline/connecting-usb-devices-to-wsl/#how-it-works) and the [usbipd-win repo on GitHub](https://devblogs.microsoft.com/commandline/connecting-usb-devices-to-wsl/#how-it-works).
+To learn more about how this works, see the [Windows Command Line Blog](https://devblogs.microsoft.com/commandline/connecting-usb-devices-to-wsl/#how-it-works) and the [usbipd-win repo on GitHub](https://github.com/dorssel/usbipd-win).
 
 For a video demonstration, see [WSL 2: Connect USB devices (Tabs vs Spaces show)](https://www.youtube.com/watch?v=I2jOuLU4o8E).


### PR DESCRIPTION
The link to the usbipd-win GitHub repo was incorrectly pointing back to the Windows Command Line Blog. It has been updated to point to the correct repository at https://github.com/dorssel/usbipd-win.