### PR TITLE
Fix broken PostgreSQL extension link in WSL database tutorial (#2310)

### DIFF
--- a/WSL/tutorials/wsl-database.md
+++ b/WSL/tutorials/wsl-database.md
@@ -195,7 +195,7 @@ To see what user accounts have been created on your PostgreSQL installation, use
 
 For more about working with PostgreSQL databases, see the [PostgreSQL docs](https://www.postgresql.org/docs/current/tutorial-createdb.html).
 
-To work with PostgreSQL databases in VS Code, try the [PostgreSQL extension](https://marketplace.visualstudio.com/items?itemName=ms-ossdata.vscode-postgresql).
+To work with PostgreSQL databases in VS Code, try the [PostgreSQL extension](https://marketplace.visualstudio.com/items?itemName=ms-ossdata.vscode-pgsql).
 
 ## Install MongoDB
 


### PR DESCRIPTION
This PR fixes the broken link to the PostgreSQL extension in the WSL database tutorial.

The original link (`ms-ossdata.vscode-postgresql`) returned a 404 error.  
Updated it to the correct extension: `ms-ossdata.vscode-pgsql`.

Fixes #2310
