### PR TITLE
Update uhfHeaderId to DevTools in docfx

### DIFF
--- a/WSL/docfx.json
+++ b/WSL/docfx.json
@@ -34,7 +34,7 @@
     "externalReference": [],
     "globalMetadata": {
       "breadcrumb_path": "/windows/wsl/breadcrumb/toc.json",
-      "uhfHeaderId": "MSDocsHeader-Windows",
+      "uhfHeaderId": "MSDocsHeader-Windows-DevTools",
       "recommendations": true,
       "feedback_product_url": "https://github.com/microsoft/WSL/issues",
       "feedback_system": "OpenSource",


### PR DESCRIPTION
Updating the top menu to use the Windows Developer Tools menu instead of the generic Windows menu.