### PR TITLE
Removed extra backtick from command

### DIFF
--- a/WSL/networking.md
+++ b/WSL/networking.md
@@ -68,7 +68,7 @@ If you want to access a networking app running on Windows (for example an app ru
 1. Obtain the IP address of your host machine by running this command from your Linux distribution:
 
     ```bash
-    ip route show | grep -i default | awk '{ print $3}'`
+    ip route show | grep -i default | awk '{ print $3}'
     ```
 
 2. Connect to any Windows server using the copied IP address.


### PR DESCRIPTION
A small PR to remove the extra backtick, this prevents copy and paste since it don't work right away