### PR TITLE
Added `--location` to install options

### DIFF
--- a/WSL/basic-commands.md
+++ b/WSL/basic-commands.md
@@ -22,6 +22,7 @@ Options include:
 - `--distribution`: Specify the Linux distribution to install. You can find available distributions by running `wsl --list --online`.
 - `--no-launch`: Install the Linux distribution but do not launch it automatically.
 - `--web-download`: Install from an online source rather than using the Microsoft Store.
+- `--location`: Specify which folder you would like to install the WSL distribution to.
 
 When WSL is not installed options include:
 


### PR DESCRIPTION
This pull request adds documentation for a new installation option in WSL, making it clearer how users can specify the installation folder for their Linux distribution.

Documentation update:

* Added the `--location` option to the list of WSL installation options in `WSL/basic-commands.md`, allowing users to specify the folder for installing the WSL distribution.