### PR TITLE
docs: correct hostname flags and command references in networking.md

### DIFF
--- a/WSL/networking.md
+++ b/WSL/networking.md
@@ -20,12 +20,12 @@ There are two scenarios to consider when identifying the IP address used for a L
 The Windows host can use command:
 
 ```powershell
-wsl.exe --distribution <DistroName> hostname -i
+wsl.exe --distribution <DistroName> hostname -I
 ```
 
 If querying the default distribution, this part of the command designating the distribution can be omitted: `-d <DistroName>`. Be sure to use a lower-case `-i` flag.
 
-Under the hood, host command wsl.exe launches the target instance and executes Linux command `hostname --ip-addresses`. This command then prints the IP address of the WSL instance to `STDOUT`. The `STDOUT` text content is then relayed back to wsl.exe. Finally, wsl.exe displays that output to the command line.
+Under the hood, host command wsl.exe launches the target instance and executes Linux command `hostname --all-ip-addresses`. This command then prints the IP address of the WSL instance to `STDOUT`. The `STDOUT` text content is then relayed back to wsl.exe. Finally, wsl.exe displays that output to the command line.
 
 A typical output might be:
 
@@ -115,7 +115,7 @@ Using `listenaddress=0.0.0.0` will listen on all [IPv4 ports](https://stackoverf
 
 ## IPv6 access
 
-- `wsl hostname -i` for the IP address of your Linux distribution installed via WSL 2 (the WSL 2 VM address)
+- `wsl hostname -I` for the IP address of your Linux distribution installed via WSL 2 (the WSL 2 VM address)
 - `ip route show | grep -i default | awk '{ print $3}'` for the IP address of the Windows machine as seen from WSL 2 (the WSL 2 VM)
 
 Using `listenaddress=0.0.0.0` will listen on all [IPv4 ports](https://stackoverflow.com/questions/9987409/want-to-know-what-is-ipv4-and-ipv6#:~:text=The%20basic%20difference%20is%20the,whereas%20IPv6%20has%20128%20bits.).


### PR DESCRIPTION
This PR updates the networking documentation to use the correct hostname flags so users receive accurate IP address information in WSL. Closes issue #2174

Changes Made:
Step 1 Replaced the Windows-host command example that used a lowercase -i:
-Old: wsl.exe --distribution <DistroName> hostname -i
-New: wsl.exe --distribution <DistroName> hostname -I

Step 2 Replaced the incorrect long option shown in the under-the-hood explanation:
-Old: hostname --ip-addresses
-New: hostname --all-ip-addresses

Step 3 Updated the IPv6/access section command that referenced the lowercase -i:
-Old: wsl hostname -i
-New: wsl hostname -I

Now it clearly explains that -i shows a placeholder/loopback IP, while -I shows all real IP addresses, so users don’t get confused and accidentally use the wrong command.

Files changed
WSL/networking.md 
Closes Issue
 #2174