### PR TITLE
Fixes misspell in command to identify IP address in WSL

### DIFF
--- a/WSL/basic-commands.md
+++ b/WSL/basic-commands.md
@@ -169,7 +169,7 @@ To terminate the specified distribution, or stop it from running, replace `<Dist
 
 ## Identify IP address
 
-- `wsl hostname -I`: Returns the IP address of your Linux distribution installed via WSL 2 (the WSL 2 VM address)
+- `hostname -i`: Returns the IP address of your Linux distribution installed via WSL 2 (the WSL 2 VM address)
 - `ip route show | grep -i default | awk '{ print $3}'`: Returns the IP address of the Windows machine as seen from WSL 2 (the WSL 2 VM)
 
 For a more detailed explanation, see [Accessing network applications with WSL: Identify IP Address](./networking.md#identify-ip-address).


### PR DESCRIPTION
1. Fixing misspelling of `-I` parameter which does not exist and should be `-i`.
2. Removed `wsl` to get rid of confusion. Because the following command in the section doesn't have `wsl`.