### PR TITLE
Update stale WSL + VS Code and Windows Server install pages

### DIFF
--- a/WSL/install-on-server.md
+++ b/WSL/install-on-server.md
@@ -47,10 +47,12 @@ Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-L
 ### Install the WSL Kernel update for WSL 2
 
 > [!NOTE]
-> This step is only needed for Windows Server 2019. On Server 2022 and later, use `wsl --update` instead:
-> ```powershell
-> wsl --update
-> ```
+> To use WSL 2, install or update the WSL kernel using the method for your Windows Server version:
+> - On Windows Server 2022 and later, run:
+>   ```powershell
+>   wsl --update
+>   ```
+> - On Windows Server 2019, install the WSL 2 kernel update using the MSI package shown below.
 
 For Windows Server 2019, you can install the WSL 2 kernel update using the MSI package:
 

--- a/WSL/install-on-server.md
+++ b/WSL/install-on-server.md
@@ -1,7 +1,7 @@
 ---
 title: Install Linux Subsystem on Windows Server
 description: Learn how to install the Linux Subsystem on Windows Server. WSL is available for installation on Windows Server 2019 (version 1709) and later.
-ms.date: 06/14/2022
+ms.date: 04/15/2026
 ms.topic: install-set-up-deploy
 ---
 
@@ -9,15 +9,15 @@ ms.topic: install-set-up-deploy
 
 The Windows Subsystem for Linux (WSL) is available for installation on Windows Server 2019 (version 1709) and later. This guide will walk through the steps of enabling WSL on your machine.
 
-## Install WSL on Windows Server 2022 and 2025 Desktop Experience
+## Install WSL on Windows Server 2022 and 2025
 
-[Windows Server 2022](/windows-server/get-started/whats-new-in-windows-server-2022) now supports a simple WSL installation using the command:
+[Windows Server 2022](/windows-server/get-started/whats-new-in-windows-server-2022) and [Windows Server 2025](/windows-server/get-started/whats-new-in-windows-server-2025) support a simple WSL installation using the command:
 
 ```powershell
 wsl.exe --install
 ```
 
-You can now install everything you need to run WSL on Windows Server 2022 by entering this command in an **administrator** PowerShell and then restarting your machine.
+You can now install everything you need to run WSL on Windows Server 2022 or 2025 (including Server Core on 2025) by entering this command in an **administrator** PowerShell and then restarting your machine.
 
 This command will enable the required optional components, download the latest Linux kernel, set WSL 2 as your default, and install a Linux distribution for you *(Ubuntu by default)*.
 
@@ -46,7 +46,13 @@ Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-L
 
 ### Install the WSL Kernel update for WSL 2
 
-This is not necessary for server core 2025.
+> [!NOTE]
+> This step is only needed for Windows Server 2019. On Server 2022 and later, use `wsl --update` instead:
+> ```powershell
+> wsl --update
+> ```
+
+For Windows Server 2019, you can install the WSL 2 kernel update using the MSI package:
 
 ```powershell
 Invoke-WebRequest -Uri "https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi" -OutFile ".\wsl_update_x64.msi"

--- a/WSL/tutorials/wsl-vscode.md
+++ b/WSL/tutorials/wsl-vscode.md
@@ -2,7 +2,7 @@
 title: Get started using VS Code with WSL
 description: Learn how to set up VS Code to author and debug code using the Windows Subsystem for Linux.
 keywords: wsl, windows, windowssubsystem, gnu, linux, bash, vs code, remote extension, debug, path, visual studio
-ms.date: 09/27/2021
+ms.date: 04/15/2026
 ms.topic: get-started
 ---
 
@@ -25,10 +25,7 @@ Visual Studio Code, along with the WSL extension, enables you to use WSL as your
 
 * When prompted to **Select Additional Tasks** during installation, be sure to check the **Add to PATH** option so you can easily open a folder in WSL using the code command.
 
-* Install the [Remote Development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack). This extension pack includes the WSL extension, in addition to the Remote - SSH, and Dev Containers extensions, enabling you to open any folder in a container, on a remote machine, or in WSL.
-
-> [!IMPORTANT]
-> In order to install the WSL extension, you will need the [1.35 May release](https://code.visualstudio.com/updates/v1_35) version or later of VS Code. We do not recommend using WSL in VS Code without the WSL extension as you will lose support for auto-complete, debugging, linting, etc. Fun fact: this WSL extension is installed in $HOME/.vscode/extensions (enter the command `ls $HOME\.vscode\extensions\` in PowerShell).
+* Install the [WSL extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl). If you also plan to work with remote machines or Dev Containers, you can install the [Remote Development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) instead, which includes the WSL extension along with Remote - SSH and Dev Containers.
 
 ## Update your Linux distribution
 
@@ -86,11 +83,11 @@ To install Git, see [set up Git to work with Windows Subsystem for Linux](./wsl-
 
 ## Install Windows Terminal (optional)
 
-The new Windows Terminal enables multiple tabs (quickly switch between Command Prompt, PowerShell, or multiple Linux distributions), custom key bindings (create your own shortcut keys for opening or closing tabs, copy+paste, etc.), emojis ☺, and custom themes (color schemes, font styles and sizes, background image/blur/transparency). Learn more in the [Windows Terminal docs](/windows/terminal).
+Windows Terminal enables multiple tabs (quickly switch between Command Prompt, PowerShell, or multiple Linux distributions), custom key bindings (create your own shortcut keys for opening or closing tabs, copy+paste, etc.), emojis ☺, and custom themes (color schemes, font styles and sizes, background image/blur/transparency). Windows Terminal comes pre-installed on Windows 11. Learn more in the [Windows Terminal docs](/windows/terminal).
 
 1. Get [Windows Terminal in the Microsoft Store](https://apps.microsoft.com/detail/9N0DX20HK701): By installing via the store, updates are handled automatically.
 
-2. Once installed, open Windows Terminal and select **Settings** to customize your terminal using the `profile.json` file.
+2. Once installed, open Windows Terminal and select **Settings** to customize your terminal using the `settings.json` file.
 
 ## Additional Resources
 
@@ -99,9 +96,8 @@ The new Windows Terminal enables multiple tabs (quickly switch between Command P
 * [Remote development tips and tricks](https://code.visualstudio.com/docs/remote/troubleshooting)
 * [Using Docker with WSL 2 and VS Code](https://code.visualstudio.com/blogs/2020/03/02/docker-in-wsl2)
 * [Using C++ and WSL in VS Code](https://code.visualstudio.com/docs/cpp/config-wsl)
-* [Remote R Service for Linux](/visualstudio/rtvs/setting-up-remote-r-service-on-linux)
 
 A few additional extensions you may want to consider include:
 
 * [Keymaps from other editors](https://marketplace.visualstudio.com/search?target=VSCode&category=Keymaps&sortBy=Downloads): These extensions can help your environment feel right at home if you're transitioning from another text editor (like Atom, Sublime, Vim, eMacs, Notepad++, etc).
-* [Settings Sync](https://marketplace.visualstudio.com/items?itemName=Shan.code-settings-sync): Enables you to synchronize your VS Code settings across different installations using GitHub. If you work on different machines, this helps keep your environment consistent across them.
+* [Settings Sync](https://code.visualstudio.com/docs/configure/settings-sync): VS Code has built-in Settings Sync that lets you synchronize your settings, extensions, and keybindings across different machines using your GitHub or Microsoft account.


### PR DESCRIPTION
## Summary

Accuracy pass on two high-traffic pages that hadn't been reviewed since 2021 and 2022 respectively (~37K combined page views/month).

### wsl-vscode.md (last reviewed Sep 2021, ~20K PVs/month)

- **Extension install**: Now recommends the standalone [WSL extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) as the primary option, with the Remote Development extension pack as an optional alternative for users who also need Remote-SSH / Dev Containers. Previously recommended the full pack only.
- **Removed**: Outdated `[!IMPORTANT]` callout requiring VS Code 1.35 (May 2019) — irrelevant for any current user.
- **Settings Sync**: Replaced recommendation for the deprecated community extension (`Shan.code-settings-sync`) with VS Code's [built-in Settings Sync](https://code.visualstudio.com/docs/configure/settings-sync), available since VS Code 1.48 (July 2020).
- **Windows Terminal**: Removed 'new' (it shipped in 2019 and is pre-installed on Windows 11); corrected `profile.json` → `settings.json`.
- **Removed**: Deprecated link to RTVS (R Tools for Visual Studio), which was discontinued.

### install-on-server.md (last reviewed Jun 2022, ~17K PVs/month)

- **Server 2025**: Expanded section heading to include Server 2025 with its own link; noted that Server Core on 2025 supports `wsl --install` directly (previously the heading said 'Desktop Experience' only, implying Server Core was excluded).
- **Kernel update**: Added `wsl --update` as the modern approach for Server 2022+. The MSI download method is now correctly scoped to Server 2019 only.